### PR TITLE
feat: add base request handler

### DIFF
--- a/src/db_action_response.py
+++ b/src/db_action_response.py
@@ -1,0 +1,13 @@
+
+from collections import namedtuple
+from dataclasses import dataclass, field
+
+
+
+@dataclass
+class DbActionResponse:
+    request: dict
+    success: bool
+    message: str
+    details: dict
+    errors: str

--- a/src/db_request_registry.py
+++ b/src/db_request_registry.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2022 NOAA
+All rights reserved.
+
+Collection request handlers registrations.  This module helps define
+the request handler format as well as the module definitions for each
+request type
+
+"""
+from collections import namedtuple
+from regions import RegionRequest
+from experiments import ExperimentRequest
+from db_action_response import DbActionResponse
+
+
+NAMED_TUPLES_LIST = 'tuples_list'
+PANDAS_DATAFRAME = 'pandas_dataframe'
+
+INNOV_TEMPERATURE_NETCDF = 'innov_temperature_netcdf'
+
+
+RequestHandler = namedtuple(
+    'RequestHandler',
+    [
+        'description',
+        'request',
+        'result'
+    ],
+)
+
+request_registry = {
+    'region': RequestHandler(
+        'Add or get regions',
+        RegionRequest,
+        DbActionResponse
+    ),
+    'experiment': RequestHandler(
+        'Add or get or update experiment registration data',
+        ExperimentRequest,
+        DbActionResponse
+    )
+}

--- a/src/score_db_base.py
+++ b/src/score_db_base.py
@@ -1,0 +1,96 @@
+"""
+Copyright 2022 NOAA
+All rights reserved.
+
+Collection of methods to facilitate handling of score db requests
+
+"""
+import argparse
+
+from yaml_utils import YamlLoader
+import db_request_registry as dbrr
+
+def handle_request(request_info):
+    """
+    Gets db request as either a yaml file or dict and returns
+    a tuple with the results of the request
+
+    Parameters
+    ----------
+    request_info: dict or str
+        The dict or yaml file containing the db GET, POST, PUT, PATCH, DELETE
+        request.
+
+    Returns
+    -------
+    db_response: tuple (need to define a standard response dataclass)
+        A tuple containing result of request and return payload if the
+        request was a data query
+    """
+
+    # Convert incoming query (either dictionary or file) to dictionary
+    if isinstance(request_info, dict):
+        db_request_dict = request_info
+    else:
+        # Create dictionary from the input file
+        db_request_dict = YamlLoader(request_info).load()[0]
+
+    # Determine which request to use: note 'request_name' must exist
+    # in the db_request yaml/dict and should point to one of the
+    # registered requests (each request should be registered in
+    # src/db_request_registry.py, see db_request_registry.py for example registered
+    # requests).
+    try:
+        request_name = db_request_dict.get('request_name')
+        print(f'request_name: {request_name}')
+        print(f'db_request_registry: {dbrr.request_registry}, ' \
+                f'type(request_registry): {type(dbrr.request_registry)}')
+        db_request_handler = dbrr.request_registry.get(request_name)
+    except Exception as err:
+        msg = f'could not find request from request_dict: {db_request_dict}'
+        raise KeyError(msg) from err
+
+    print(f'db_request_handler.name: {db_request_handler.name}')
+    db_request = db_request_handler.request(db_request_dict)
+    print(f'type(request_meta): {type(request_meta)}')
+    response = db_request.submit()
+    # check type of response.  Must be a specific dataclass defined in registry
+    return response
+
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def main():
+    """
+    If the db request app is kicked off from command line, this is the entry
+    point.
+
+    Parameters
+    ----------
+    args: a list of arguments - in this case only one argument is allowed
+    and must be a yaml file containing the db request
+    """
+
+    # Arguments
+    # ---------
+    parser = argparse.ArgumentParser()
+    parser.add_argument('request_yaml', type=str, help='Request ' \
+                        'YAML file for describing the request.')
+
+    # Get the configuation file
+    args = parser.parse_args()
+    request_yaml = args.request_yaml
+
+    file_utils.is_valid_readable_file(request_yaml)
+
+    # Submit the score db request
+    handle_request(request_yaml)
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    main()

--- a/src/score_db_base.py
+++ b/src/score_db_base.py
@@ -86,7 +86,7 @@ def main():
     file_utils.is_valid_readable_file(request_yaml)
 
     # Submit the score db request
-    handle_request(request_yaml)
+    return handle_request(request_yaml)
 
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
body: this code will still be non-functional and will need a
specific request handler.  This handler receives either a dict
or yaml file which describes the type of request (GET, PUT), the
tables to insert or receive data from, and the specific filters.
This will act much like a REST api, but will not require an http
request.  These request handlers could be modified fairly easily
to transform them into actual REST apis.