### PR TITLE
update regions table to use numeric values

### DIFF
--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -267,6 +267,14 @@ def get_regions_filter(filter_dict, constructed_filter):
     constructed_filter = get_string_filter(
         filter_dict, rgs, 'name', constructed_filter, 'rgs_name')
 
+    constructed_filter = get_string_filter(filter_dict, rgs, 'min_lat', constructed_filter, 'min_lat')
+
+    constructed_filter = get_string_filter(filter_dict, rgs, 'max_lat', constructed_filter, 'max_lat')
+
+    constructed_filter = get_string_filter(filter_dict, rgs, 'min_lon', constructed_filter, 'min_lon')
+
+    constructed_filter = get_string_filter(filter_dict, rgs, 'max_lon', constructed_filter, 'max_lon')
+
     return constructed_filter
 
 def get_expt_record(body):

--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -177,6 +177,22 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
 
     return constructed_filter
 
+def get_float_filter(filters, cls, key, constructed_filter):
+    if not isinstance(filters, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filters)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    float_flt = filters.get(key)
+
+    if float_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    constructed_filter[key] = ( getattr(cls, key) == float_flt )
+    
+    return constructed_filter
 
 def get_experiments_filter(filter_dict, constructed_filter):
     if not isinstance(filter_dict, dict):
@@ -267,13 +283,13 @@ def get_regions_filter(filter_dict, constructed_filter):
     constructed_filter = get_string_filter(
         filter_dict, rgs, 'name', constructed_filter, 'rgs_name')
 
-    constructed_filter = get_string_filter(filter_dict, rgs, 'min_lat', constructed_filter, 'min_lat')
+    constructed_filter = get_float_filter(filter_dict, rgs, 'min_lat', constructed_filter)
 
-    constructed_filter = get_string_filter(filter_dict, rgs, 'max_lat', constructed_filter, 'max_lat')
+    constructed_filter = get_float_filter(filter_dict, rgs, 'max_lat', constructed_filter)
 
-    constructed_filter = get_string_filter(filter_dict, rgs, 'min_lon', constructed_filter, 'min_lon')
+    constructed_filter = get_float_filter(filter_dict, rgs, 'min_lon', constructed_filter)
 
-    constructed_filter = get_string_filter(filter_dict, rgs, 'max_lon', constructed_filter, 'max_lon')
+    constructed_filter = get_float_filter(filter_dict, rgs, 'max_lon', constructed_filter)
 
     return constructed_filter
 

--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -177,14 +177,14 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
 
     return constructed_filter
 
-def get_float_filter(filters, cls, key, constructed_filter):
-    if not isinstance(filters, dict):
+def get_float_filter(filter_dict, cls, key, constructed_filter):
+    if not isinstance(filter_dict, dict):
         msg = f'Invalid type for filters, must be \'dict\', was ' \
-            f'type: {type(filters)}'
+            f'type: {type(filter_dict)}'
         raise TypeError(msg)
 
     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-    float_flt = filters.get(key)
+    float_flt = filter_dict.get(key)
 
     if float_flt is None:
         print(f'No \'{key}\' filter detected')

--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -287,9 +287,9 @@ def get_regions_filter(filter_dict, constructed_filter):
 
     constructed_filter = get_float_filter(filter_dict, rgs, 'max_lat', constructed_filter)
 
-    constructed_filter = get_float_filter(filter_dict, rgs, 'min_lon', constructed_filter)
+    constructed_filter = get_float_filter(filter_dict, rgs, 'east_lon', constructed_filter)
 
-    constructed_filter = get_float_filter(filter_dict, rgs, 'max_lon', constructed_filter)
+    constructed_filter = get_float_filter(filter_dict, rgs, 'west_lon', constructed_filter)
 
     return constructed_filter
 

--- a/src/regions.py
+++ b/src/regions.py
@@ -182,7 +182,8 @@ def get_regions_from_name_list(region_names):
 
     rr = RegionRequest(request_dict)
     return rr.submit()
-    
+
+#formats sqlalchmey where clause statements for sql to filter per user inputed string values     
 def get_string_filter(filters, cls, key, constructed_filter):
         if not isinstance(filters, dict):
             msg = f'Invalid type for filters, must be \'dict\', was ' \
@@ -208,6 +209,7 @@ def get_string_filter(filters, cls, key, constructed_filter):
 
         return constructed_filter
 
+#formats sqlalchmey where clause statements for sql to filter per user inputed float values
 def get_float_filter(filters, cls, key, constructed_filter):
     if not isinstance(filters, dict):
         msg = f'Invalid type for filters, must be \'dict\', was ' \
@@ -225,6 +227,7 @@ def get_float_filter(filters, cls, key, constructed_filter):
     
     return constructed_filter
 
+#constructs all sqlalchmey filter statements for region values
 def construct_filters(filters):
         constructed_filter = {}
 

--- a/src/regions.py
+++ b/src/regions.py
@@ -77,10 +77,6 @@ class Region:
             msg = f'min_lat must be less than max_lat - ' \
                 f'min_lat: {self.min_lat}, max_lat: {self.max_lat}'
             raise ValueError(msg)
-        if self.max_lat < self.min_lat:
-            msg = f'max_lat must be greater than min_lat - min_lat: {self.min_lat}, '\
-                f'max_lat: {self.max_lat}'
-            raise ValueError(msg)
         if abs(self.min_lat) > 90 or abs(self.max_lat) > 90:
             msg = f'min_lat or max_lat is out of allowed range, must be greater' \
                 f' than -90 and less than 90 - min_lat: {self.min_lat}, ' \

--- a/src/regions.py
+++ b/src/regions.py
@@ -228,18 +228,35 @@ def get_string_filter(filters, cls, key, constructed_filter):
 
         return constructed_filter
 
+def get_float_filter(filters, cls, key, constructed_filter):
+    if not isinstance(filters, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filters)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    float_flt = filters.get(key)
+
+    if float_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    constructed_filter[key] = ( getattr(cls, key) == float_flt )
+    
+    return constructed_filter
+
 def construct_filters(filters):
         constructed_filter = {}
 
         constructed_filter = get_string_filter(filters, rg, 'name', constructed_filter)
 
-        constructed_filter = get_string_filter(filters, rg, 'min_lat', constructed_filter)
+        constructed_filter = get_float_filter(filters, rg, 'min_lat', constructed_filter)
 
-        constructed_filter = get_string_filter(filters, rg, 'max_lat', constructed_filter)
+        constructed_filter = get_float_filter(filters, rg, 'max_lat', constructed_filter)
 
-        constructed_filter = get_string_filter(filters, rg, 'min_lon', constructed_filter)
+        constructed_filter = get_float_filter(filters, rg, 'min_lon', constructed_filter)
 
-        constructed_filter = get_string_filter(filters, rg, 'max_lon', constructed_filter)
+        constructed_filter = get_float_filter(filters, rg, 'max_lon', constructed_filter)
 
         return constructed_filter
 
@@ -396,7 +413,7 @@ class RegionRequest:
             rg
         )
 
-        print('Before addinng filters to region request###')
+        print('Before adding filters to region request###')
         for key, value in constructed_filters.items():
             q = q.filter(value)
         print('After adding regions filter')

--- a/src/regions.py
+++ b/src/regions.py
@@ -37,13 +37,6 @@ FILTER__BY_REGION_DATA = 'by_data'
 VALID_FILTER_TYPES = [
     FILTER__NONE, FILTER__BY_REGION_NAME, FILTER__BY_REGION_DATA]
 
-EQUATORIAL = {'name': 'equatorial', 'min_lat': -5.0, 'max_lat': 5.0, 'min_lon': 0.0, 'max_lon': 360.0}
-GLOBAL = {'name': 'global', 'min_lat': -90.0, 'max_lat': 90.0, 'min_lon': 0.0, 'max_lon': 360.0}
-NORTH_MIDLAT = {'name': 'north_midlatitudes', 'min_lat': 20.0, 'max_lat': 60.0, 'min_lon': 0.0, 'max_lon': 360.0}
-TROPICS = {'name': 'tropics', 'min_lat': -20.0, 'max_lat': 20.0, 'min_lon': 0.0, 'max_lon': 360.0}
-SOUTH_MIDLAT = {'name': 'south_midlatitudes', 'min_lat': -60.0, 'max_lat': -20.0, 'min_lon': 0.0, 'max_lon': 360.0}
-TEST_SOUTH_HEMIS = {'name': 'test_south_hemis', 'min_lat': -50.0, 'max_lat': -35.0, 'min_lon': 0.0, 'max_lon': 360.0}
-
 RegionData = namedtuple(
     'RegionData',
     [

--- a/src/regions.py
+++ b/src/regions.py
@@ -4,7 +4,7 @@ All rights reserved.
 
 Collection of methods and classes to facilitate insertion and selection
 of records into/from the 'regions' table.  The region table includes the
-following columns ['name', 'bounds', 'created_at', 'updated_at'] and each
+following columns ['name', 'min_lat', 'max_lat', 'min_lon', 'max_lon', 'created_at', 'updated_at'] and each
 row's id serves as a foreign key to the 'expt_metrics' table.  A unique
 region consists of a combination of the name and the bounds values.
 Multiple regions with the same 'name' value are allowed as long as the
@@ -22,16 +22,11 @@ import json
 from db_action_response import DbActionResponse
 import score_table_models as stm
 from score_table_models import Region as rg
+import db_utils
 
 from pandas import DataFrame
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.inspection import inspect
-
-MIN_LONG = -180.0
-MAX_LONG = 180.0
-
-HTTP_GET = 'GET'
-HTTP_PUT = 'PUT'
 
 PARAM_FILTER_TYPE = 'filter_type'
 
@@ -39,7 +34,6 @@ FILTER__NONE = 'none'
 FILTER__BY_REGION_NAME = 'by_name'
 FILTER__BY_REGION_DATA = 'by_data'
 
-VALID_METHODS = [HTTP_GET, HTTP_PUT]
 VALID_FILTER_TYPES = [
     FILTER__NONE, FILTER__BY_REGION_NAME, FILTER__BY_REGION_DATA]
 
@@ -58,29 +52,31 @@ RegionData = namedtuple(
         'name',
         'min_lat',
         'max_lat',
-        'grid',
-        'hash_val'
+        'min_lon',
+        'max_lon'
     ],
 )
 
-
-def RegionsError(Exception):
-    pass
-
+class RegionError(Exception):
+    def __init__(self, message):
+        self.message = message
+    def __str__(self):
+        return self.message
 
 @dataclass
 class Region:
-    ''' region object storing region name and min/max latitude bounds '''
+    ''' region object storing region name and min/max latitude/longitude bounds '''
     name: str
     min_lat: float
     max_lat: float
-    grid: str = field(default_factory=str, init=False)
-    hash_val: str = field(default_factory=str, init=False)
+    min_lon: float
+    max_lon: float
 
     def __post_init__(self):
         if not isinstance(self.name, str):
             msg = f'name must be a string - name {self.name}'
             raise TypeError(msg)
+        #latitude checks
         if (not isinstance(self.min_lat, float) or
             not isinstance(self.max_lat, float)):
             msg = f'min and max lat must be floats - min lat: {self.min_lat}' \
@@ -94,26 +90,36 @@ class Region:
             msg = f'max_lat must be greater than min_lat - min_lat: {self.min_lat}, '\
                 f'max_lat: {self.max_lat}'
             raise ValueError(msg)
-
         if abs(self.min_lat) > 90 or abs(self.max_lat) > 90:
             msg = f'min_lat or max_lat is out of allowed range, must be greater' \
                 f' than -90 and less than 90 - min_lat: {self.min_lat}, ' \
                 f'max_lat: {self.max_lat}'
             raise ValueError(msg)
-
-        self.grid = 'POLYGON('
-        self.grid = f'({float(MIN_LONG)} {float(self.max_lat)}),'
-        self.grid += f'({float(MAX_LONG)} {float(self.max_lat)}),'
-        self.grid += f'({float(MAX_LONG)} {float(self.min_lat)}),'
-        self.grid += f'({float(MIN_LONG)} {float(self.min_lat)}),'
-        self.grid += f'({float(MIN_LONG)} {float(self.max_lat)})'
-        self.grid += ')'
-
-        self.hash_val = self.name + self.grid
+        #longitude checks
+        if (not isinstance(self.min_lon, float) or
+            not isinstance(self.max_lon, float)):
+            msg = f'min and max lon must be floats - min lon: {self.min_lon}' \
+                f', max lon: {self.max_lon}'
+            raise ValueError(msg)
+        if self.min_lon > self.max_lon:
+            msg = f'min_lon must be less than max_lon - ' \
+                f'min_lon: {self.min_lon}, max_lon: {self.max_lon}'
+            raise ValueError(msg)
+        if self.max_lon < self.min_lon:
+            msg = f'max_lon must be greater than min_lon - min_lon: {self.min_lon}, '\
+                f'max_lon: {self.max_lon}'
+            raise ValueError(msg)
+        
+        #TODO--- THIS IS WHERE WE NEED TO HANDLE THE -180 TO 180 SYSTEM
+        if self.min_lon < 0 or self.max_lon > 360:
+            msg = f'min_lon or max_lon is out of allowed range, must be greater' \
+                f' than 0 and less than 360 - min_lon: {self.min_lon}, ' \
+                f'max_lon: {self.max_lon}'
+            raise ValueError(msg)
 
     
     def get_region_data(self):
-        return RegionData(self.name, self.min_lat, self.max_lat, self.grid, self.hash_val)
+        return RegionData(self.name, self.min_lat, self.max_lat, self.min_lon, self.max_lon)
 
 
 DEFAULT_REGIONS = [
@@ -133,8 +139,8 @@ def validate_list_of_regions(regions):
     unique_regions = set()
     try:
         for r in regions:
-            validated_region = Region(
-                r.get('name'), r.get('min_lat'), r.get('max_lat'))
+            validated_region = Region(r.get('name'), r.get('min_lat'), r.get('max_lat'), 
+                                      r.get('min_lon'), r.get('max_lon'))
             unique_regions.add(validated_region.get_region_data())
     except Exception as err:
         msg = f'problem parsing region data, regions: {regions}, err: {err}'
@@ -154,14 +160,6 @@ def validate_list_of_strings(values):
     
     return list(unique_string_list)
 
-def validate_method(method):
-    if method not in VALID_METHODS:
-        msg = f'Request type must be one of: {VALID_METHODS}, was: {method}'
-        print(msg)
-        raise ValueError(msg)
-    
-    return method
-
 
 def validate_body(method, body, filter_type=None):
     
@@ -172,7 +170,7 @@ def validate_body(method, body, filter_type=None):
     region_names = None
     regions = None
     
-    if method == HTTP_GET:
+    if method == db_utils.HTTP_GET:
         if filter_type is None:
             raise ValueError('\'filter_type\' param must be specified.')
         
@@ -182,12 +180,12 @@ def validate_body(method, body, filter_type=None):
             regions = validate_list_of_regions(body.get('regions'))
             region_names = [x.name for x in regions] 
         
-    elif method == HTTP_PUT:
+    elif method == db_utils.HTTP_PUT:
         regions = validate_list_of_regions(body.get('regions'))
         region_names = [x.name for x in regions]
     
     else:
-        raise ValueError(f'Invalid method, must be one of {VALID_METHODS}')
+        raise ValueError(f'Invalid method, must be one of {db_utils.VALID_METHODS}')
 
     print(f'region_names: {region_names}, regions: {regions}')
     return [region_names, regions]
@@ -203,6 +201,7 @@ def get_filter_type(params):
     return filter_type
 
 
+# THIS WILL LIKELY BE REMOVED AFTER REWRITING METRICS 
 def get_regions_from_name_list(region_names):
     request_dict = {
         'name': 'region',
@@ -216,6 +215,45 @@ def get_regions_from_name_list(region_names):
     rr = RegionRequest(request_dict)
     return rr.submit()
     
+def get_string_filter(filters, cls, key, constructed_filter):
+        if not isinstance(filters, dict):
+            msg = f'Invalid type for filters, must be \'dict\', was ' \
+                f'type: {type(filters)}'
+            raise TypeError(msg)
+
+        print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+        string_flt = filters.get(key)
+
+        if string_flt is None:
+            print(f'No \'{key}\' filter detected')
+            return constructed_filter
+
+        like_filter = string_flt.get('like')
+        # prefer like search over exact match if both exist
+        if like_filter is not None:
+            constructed_filter[key] = (getattr(cls, key).like(like_filter))
+            return constructed_filter
+
+        exact_match_filter = string_flt.get('exact')
+        if exact_match_filter is not None:
+            constructed_filter[key] = (getattr(cls, key) == exact_match_filter)
+
+        return constructed_filter
+
+def construct_filters(filters):
+        constructed_filter = {}
+
+        constructed_filter = get_string_filter(filters, rg, 'name', constructed_filter)
+
+        constructed_filter = get_string_filter(filters, rg, 'min_lat', constructed_filter)
+
+        constructed_filter = get_string_filter(filters, rg, 'max_lat', constructed_filter)
+
+        constructed_filter = get_string_filter(filters, rg, 'min_lon', constructed_filter)
+
+        constructed_filter = get_string_filter(filters, rg, 'max_lon', constructed_filter)
+
+        return constructed_filter
 
 @dataclass
 class RegionRequest:
@@ -229,38 +267,25 @@ class RegionRequest:
     response: dict = field(default_factory=dict, init=False)
 
     def __post_init__(self):
-        self.method = validate_method(self.request_dict.get('method'))
+        self.method = db_utils.validate_method(self.request_dict.get('method'))
         self.params = self.request_dict.get('params', {})
         self.filter_type = get_filter_type(self.params)
         self.body = self.request_dict.get('body')
         [self.region_names, self.regions] = validate_body(
             self.method, self.body, self.filter_type)
-        
-
-    def get_regions_hash_vals(self):
-        hash_vals = []
-        for region in self.regions:
-            hash_vals.append(region.hash_val)
-        return hash_vals
 
     def submit(self):
-        engine = stm.get_engine_from_settings()
-        session = stm.get_session()
-
-        if self.method == HTTP_GET:
+        if self.method == db_utils.HTTP_GET:
             error_msg = None
             message = None
             matched_json = None
             try:
                 if self.filter_type == FILTER__NONE:
-                    matched_records = self.get_regions()
+                    matched_records = self.get_all_regions()
                 elif self.filter_type == FILTER__BY_REGION_NAME:
                     matched_records = self.get_regions_by_name()
-                else:
-                    hash_vals = self.get_regions_hash_vals()
-                    if len(hash_vals) == 0:
-                        hash_vals = None
-                    matched_records = self.get_regions(hash_vals)
+                else: #Filter by Region Data
+                    matched_records = self.get_regions_by_data()
                 message = f'Request returned {len(matched_records)} record/s'
                 matched_json = matched_records.to_json(orient = 'records')
             except Exception as err:
@@ -278,78 +303,27 @@ class RegionRequest:
             )
             print(f'response: {response}')
             return response
-        elif self.method == HTTP_PUT:
-            hash_vals = self.get_regions_hash_vals()
-            
-            existing_regions = self.get_regions(hash_vals)
-            print(f'existing_regions: {existing_regions}')
-
-            records = []
-            records_hash_vals = []
-
-            for region in self.regions:
-                if (
-                    existing_regions is None or
-                    len(existing_regions) == 0 or
-                    region.hash_val not in existing_regions['unique_region'].tolist()
-                ):
-                    item = rg(
-                        name=region.name,
-                        bounds=region.grid,
-                        created_at=datetime.utcnow(),
-                        updated_at=None
-                    )
-                    records.append(item)
-                    records_hash_vals.append(region.hash_val)
-
-            success = True
-            error_msg = None
-            record_count = 0
+        elif self.method == db_utils.HTTP_PUT:
             try:
-                inserted_records = DataFrame()
-                if len(records) > 0:
-                    session.bulk_save_objects(records)
-                    session.commit()
-                    inserted_records = self.get_region_set(records_hash_vals)
-
-                message = f'Inserted {len(inserted_records)} new region/s.'
-                print(f'inserts: {inserted_records}')
+                return self.put_regions()
             except Exception as err:
-                msg = f'Failed to insert {len(records)} records - err: {err}'
-                print(msg)
-                error_msg = msg
-                message = f'Inserted {len(inserted_records)} new region/s.'
-            
-            matched_records = self.get_regions(hash_vals)
+                error_msg = f'Failed to put region record - err: {err}'
+                print(f'Submit PUT error: {error_msg}')
+                return self.failed_request(error_msg)
 
-            inserts_json = inserted_records.to_json(orient = 'records')
-            matched_json = matched_records.to_json(orient = 'records')
-
-            response = DbActionResponse(
-                self.request_dict,
-                (error_msg is None),
-                message,
-                {
-                    'inserted_records': inserts_json,
-                    'matched_records': matched_json,
-                    'records': matched_records
-                },
-                error_msg
-            )
-            print(f'response: {response}')
-            return response
-
-
+    #get regions filtered by name 
     def get_regions_by_name(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
         try:
             existing_regions = session.query(
                 rg.id,
                 rg.name,
-                rg.bounds,
+                rg.min_lat,
+                rg.max_lat,
+                rg.min_lon,
+                rg.max_lon,
                 rg.created_at,
-                rg.name.concat(rg.bounds).label('unique_region')
+                rg.updated_at
             ).select_from(
                 rg
             ).filter(
@@ -366,16 +340,19 @@ class RegionRequest:
 
         return DataFrame(existing_regions, columns = existing_regions[0]._fields)
 
+    #get all regions in database
     def get_all_regions(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
         try:
             existing_regions = session.query(
                 rg.id,
                 rg.name,
-                rg.bounds,
+                rg.min_lat,
+                rg.max_lat,
+                rg.min_lon,
+                rg.max_lon,
                 rg.created_at,
-                rg.name.concat(rg.bounds).label('unique_region')
+                rg.updated_at
             ).select_from(
                 rg
             ).all()
@@ -390,47 +367,113 @@ class RegionRequest:
 
         return DataFrame(existing_regions, columns = existing_regions[0]._fields)
     
-    def get_region_set(self, hash_vals):
-        if not isinstance(hash_vals, list):
-            msg = f'requested set must be in form of list - {type(hash_vals)}'
-            raise TypeError()
-
-        engine = stm.get_engine_from_settings()
+    #get regions based on filters on user provided restrictions on values 
+    def get_regions_by_data(self):
+        if self.params.len() < 0:
+            msg = f'To filter regions by data, there must be a params which includes filters for the data'
+            raise RegionError(msg)
+        
+        filters = self.request_dict.params.get('filters')
+        if not isinstance(filters, dict):
+            msg = f'Filters must be in teh form dict, filters: {type(filters)}'
+            raise RegionError(msg)
+        
         session = stm.get_session()
-        print(f'hash_vals: {hash_vals}')
-        # if no regions were specified in query, get all
 
-        try:
-            existing_regions = session.query(
-                rg.id,
-                rg.name,
-                rg.bounds,
-                rg.created_at,
-                rg.name.concat(rg.bounds).label('unique_region')
-            ).select_from(
-                rg
-            ).filter(
-                rg.name.concat(rg.bounds).in_(hash_vals)
-            ).all()
-        except Exception as err:
-            msg = f'Problem requesting region set - err: {err}'
-            print(msg)
-            return DataFrame()
+        q = session.query(
+            rg.id,
+            rg.name,
+            rg.min_lat,
+            rg.max_lat,
+            rg.min_lon,
+            rg.max_lon,
+            rg.created_at,
+            rg.updated_at
+        ).select_from(
+            rg
+        )
 
+        print('Before addinng filters to region request###')
+        for key, value in filters.items():
+            q = q.filter(value)
+        print('After adding regions filter')
+
+        regions = q.all()
         session.close()
-        if len(existing_regions) == 0:
-            return DataFrame()
+ 
+        results = DataFrame()
+        if len(regions) > 0:
+            results = DataFrame(regions, columns = regions[0]._fields)
+        return results
+    
+    def put_regions(self):
+        session = stm.get_session()
+        all_results = []
+        error_msgs = None
+        for region in self.regions:
+            time_now = datetime.utcnow()
 
-        return DataFrame(existing_regions, columns = existing_regions[0]._fields)
+            insert_stmt = insert(rg).values(
+                name=region.name, 
+                min_lat=region.min_lat, 
+                max_lat=region.max_lat,
+                min_lon=region.min_lon,
+                max_lon=region.max_lon,
+                created_at=time_now,
+                update_at=None
+            ).returning(rg)
 
+            do_update_stmt = insert_stmt.on_conflict_do_update(
+                constraint='unique_region',
+                set=dict(
+                    name=region.name,
+                    min_lat=region.min_lat,
+                    max_lat=region.max_lat,
+                    min_lon=region.min_lon,
+                    max_lon=region.max_lon,
+                    updated_at=time_now
+                )
+            )
 
-    def get_regions(self, hash_vals=None):
-        if hash_vals is None:
-            df = self.get_all_regions()
-        else:
-            df = self.get_region_set(hash_vals)
+            try:
+                result =session.execute(do_update_stmt)
+                session.flush()
+                result_row = result.fetchone()
+                action = db_utils.INSERT
+                if result_row.updated_at is not None:
+                    action = db_utils.UPDATE
+                session.commit()
+                session.close()
+            except Exception as err:
+                message = f'Attempt to {action} region record FAILED'
+                error_msg = f'Failed to insert/update record -err: {err}'
+                print(f'error_msg: {error_msg}')
+            else:
+                message = f'Attempt to {action} region record SUCCEEDED'
+                error_msg = None
             
+            results = {}
+            if result_row is not None:
+                results['region_name'] = region.name
+                results['action'] = action
+                results['data'] = [result_row._mapping]
+                results['id'] = result_row.index
+            
+            if results.len() > 0:
+                all_results.add(results)
+
+            if error_msg is not None:
+                error_msgs += error_msg + "\n"
+
+        
+        response = DbActionResponse(
+            self.request_dict,
+            (error_msgs is None),
+            message,
+            all_results,
+            error_msg
+        )
+        print(f'response: {response}')
+        return response   
 
             
-        print(f'df: {df}')
-        return df

--- a/src/regions.py
+++ b/src/regions.py
@@ -189,7 +189,7 @@ def get_filter_type(params):
             f'Must be one of [{VALID_FILTER_TYPES}]')
     return filter_type
 
-#used in expt metrics to check for existing regions / should get removed
+#used in expt metrics to check for existing regions
 def get_regions_from_name_list(region_names):
     request_dict = {
         'name': 'region',

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -124,15 +124,15 @@ class Region(Base):
     __tablename__ = REGIONS_TABLE
     __table_args__ = (
         UniqueConstraint('min_lat', 'max_lat',
-                         'min_lon', 'max_lon', name='unique_region'),
+                         'east_lon', 'west_lon', name='unique_region'),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(79), nullable=False)
     min_lat = Column(Float, nullable=False)
     max_lat = Column(Float, nullable=False)
-    min_lon = Column(Float, nullable=False)
-    max_lon = Column(Float, nullable=False)
+    east_lon = Column(Float, nullable=False)
+    west_lon = Column(Float, nullable=False)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime)
 

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -123,13 +123,16 @@ class ExperimentMetric(Base):
 class Region(Base):
     __tablename__ = REGIONS_TABLE
     __table_args__ = (
-        UniqueConstraint('name', 'bounds', name='unique_region'),
+        UniqueConstraint('min_lat', 'max_lat',
+                         'min_lon', 'max_lon', name='unique_region'),
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(79), nullable=False)
-    # bounds = Column(Geography(geometry_type='POLYGON', srid=4326))
-    bounds = Column(String(255), nullable=False)
+    min_lat = Column(Float, nullable=False)
+    max_lat = Column(Float, nullable=False)
+    min_lon = Column(Float, nullable=False)
+    max_lon = Column(Float, nullable=False)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime)
 

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -13,6 +13,7 @@ import score_table_models as scr_models
 from score_table_models import Region as regions_table
 import regions as rgs
 from regions import RegionData, Region, RegionRequest
+import db_utils
 
 from score_db_base import handle_request
 
@@ -58,38 +59,38 @@ def test_validate_list_of_regions():
 
 def test_validate_body():
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, None)
+        rgs.validate_body(db_utils.HTTP_GET, None)
 
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, None)
+        rgs.validate_body(db_utils.HTTP_GET, None)
 
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, [])
+        rgs.validate_body(db_utils.HTTP_GET, [])
 
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, 'foo')
+        rgs.validate_body(db_utils.HTTP_GET, 'foo')
 
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, 1)
+        rgs.validate_body(db_utils.HTTP_GET, 1)
     
 
     body = {'regions': {}}
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
+        rgs.validate_body(db_utils.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
     
     body = {'regions': [1, 2, 9]}
     with pytest.raises(TypeError):
-        rgs.validate_body(rgs.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
+        rgs.validate_body(db_utils.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
 
     body = {'regions': ['foo', 'bar', 'foo']}
-    [region_names, regions] = rgs.validate_body(rgs.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
+    [region_names, regions] = rgs.validate_body(db_utils.HTTP_GET, body, rgs.FILTER__BY_REGION_NAME)
     for name in region_names:
         assert region_names.count(name) == 1
     
     assert regions is None
 
     body = {'regions': [rgs.GLOBAL, rgs.EQUATORIAL, rgs.GLOBAL]}
-    [region_names, regions] = rgs.validate_body(rgs.HTTP_PUT, body)
+    [region_names, regions] = rgs.validate_body(db_utils.HTTP_PUT, body)
     for name in region_names:
         assert region_names.count(name) == 1
         print(f'name: {name}')
@@ -101,7 +102,7 @@ def test_validate_body():
 def test_request_put_regions():
     request_dict = {
         'name': 'region',
-        'method': 'PUT',
+        'method': db_utils.HTTP_PUT,
         'body': {
             'regions': [
                 rgs.GLOBAL,
@@ -120,7 +121,7 @@ def test_request_put_regions():
 def test_request_get_specific_regions_by_name():
     request_dict = {
         'name': 'region',
-        'method': 'GET',
+        'method': db_utils.HTTP_GET,
         'params': {'filter_type': 'by_name'},
         'body': {
             'regions': [
@@ -138,7 +139,7 @@ def test_request_get_specific_regions_by_name():
 def test_request_get_specific_regions_by_region_data():
     request_dict = {
         'name': 'region',
-        'method': 'GET',
+        'method': db_utils.HTTP_GET,
         'params': {'filter_type': 'by_data', 'filters': {'min_lon': 0.0},},
     }
 
@@ -149,7 +150,7 @@ def test_request_get_specific_regions_by_region_data():
 def test_request_all_regions():
     request_dict = {
         'name': 'region',
-        'method': 'GET',
+        'method': db_utils.HTTP_GET,
         'params': {'filter_type': 'none'},
         'body': {
             'regions': [

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -16,24 +16,6 @@ from regions import RegionData, Region, RegionRequest
 
 from score_db_base import handle_request
 
-
-
-# scr_models.init_tables()
-
-def test_validate_method():
-    with pytest.raises(ValueError):
-        rgs.validate_method('blah')
-    
-    with pytest.raises(ValueError):
-        rgs.validate_method(None)
-    
-    with pytest.raises(ValueError):
-        rgs.validate_method([])
-    
-    for method in rgs.VALID_METHODS:
-        rgs.validate_method(method)
-
-
 def test_validate_list_of_strings():
     with pytest.raises(TypeError):
         rgs.validate_list_of_strings({})

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -17,6 +17,13 @@ import db_utils
 
 from score_db_base import handle_request
 
+#test regions
+EQUATORIAL = {'name': 'equatorial', 'min_lat': -5.0, 'max_lat': 5.0, 'min_lon': 0.0, 'max_lon': 360.0}
+GLOBAL = {'name': 'global', 'min_lat': -90.0, 'max_lat': 90.0, 'min_lon': 0.0, 'max_lon': 360.0}
+NORTH_MIDLAT = {'name': 'north_midlatitudes', 'min_lat': 20.0, 'max_lat': 60.0, 'min_lon': 0.0, 'max_lon': 360.0}
+TROPICS = {'name': 'tropics', 'min_lat': -20.0, 'max_lat': 20.0, 'min_lon': 0.0, 'max_lon': 360.0}
+SOUTH_MIDLAT = {'name': 'south_midlatitudes', 'min_lat': -60.0, 'max_lat': -20.0, 'min_lon': 0.0, 'max_lon': 360.0}
+
 def test_validate_list_of_strings():
     with pytest.raises(TypeError):
         rgs.validate_list_of_strings({})
@@ -49,7 +56,7 @@ def test_validate_list_of_regions():
     with pytest.raises(TypeError):
         rgs.validate_list_of_regions(1)
 
-    region_list = [rgs.EQUATORIAL, rgs.GLOBAL, rgs.SOUTH_MIDLAT, rgs.GLOBAL]
+    region_list = [EQUATORIAL, GLOBAL, SOUTH_MIDLAT, GLOBAL]
     validated_regions = rgs.validate_list_of_regions(region_list)
     print(f'validated_regions: {validated_regions}')
     for region in validated_regions:
@@ -89,7 +96,7 @@ def test_validate_body():
     
     assert regions is None
 
-    body = {'regions': [rgs.GLOBAL, rgs.EQUATORIAL, rgs.GLOBAL]}
+    body = {'regions': [GLOBAL, EQUATORIAL, GLOBAL]}
     [region_names, regions] = rgs.validate_body(db_utils.HTTP_PUT, body)
     for name in region_names:
         assert region_names.count(name) == 1
@@ -105,12 +112,12 @@ def test_request_put_regions():
         'method': db_utils.HTTP_PUT,
         'body': {
             'regions': [
-                rgs.GLOBAL,
-                rgs.EQUATORIAL,
-                rgs.NORTH_MIDLAT,
-                rgs.SOUTH_MIDLAT,
-                rgs.TROPICS,
-                rgs.GLOBAL,
+                GLOBAL,
+                EQUATORIAL,
+                NORTH_MIDLAT,
+                SOUTH_MIDLAT,
+                TROPICS,
+                GLOBAL,
             ]
         }
     }
@@ -125,10 +132,10 @@ def test_request_get_specific_regions_by_name():
         'params': {'filter_type': 'by_name'},
         'body': {
             'regions': [
-                rgs.GLOBAL.get('name'),
-                rgs.EQUATORIAL.get('name'),
-                rgs.NORTH_MIDLAT.get('name'),
-                rgs.SOUTH_MIDLAT.get('name'),
+                GLOBAL.get('name'),
+                EQUATORIAL.get('name'),
+                NORTH_MIDLAT.get('name'),
+                SOUTH_MIDLAT.get('name'),
             ]
         }
     }
@@ -154,10 +161,10 @@ def test_request_all_regions():
         'params': {'filter_type': 'none'},
         'body': {
             'regions': [
-                rgs.GLOBAL,
-                rgs.EQUATORIAL,
-                rgs.NORTH_MIDLAT,
-                rgs.SOUTH_MIDLAT,
+                GLOBAL,
+                EQUATORIAL,
+                NORTH_MIDLAT,
+                SOUTH_MIDLAT,
             ]
         }
     }

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -48,7 +48,7 @@ def test_validate_list_of_regions():
     with pytest.raises(TypeError):
         rgs.validate_list_of_regions(1)
 
-    region_list = [rgs.EQUATORIAL, rgs.GLOBAL, rgs.SOUTH_HEMIS, rgs.GLOBAL]
+    region_list = [rgs.EQUATORIAL, rgs.GLOBAL, rgs.SOUTH_MIDLAT, rgs.GLOBAL]
     validated_regions = rgs.validate_list_of_regions(region_list)
     print(f'validated_regions: {validated_regions}')
     for region in validated_regions:
@@ -98,69 +98,6 @@ def test_validate_body():
         assert regions.count(region) == 1
         assert isinstance(region, RegionData)
 
-
-def test_initialize_region_request_prep():
-
-    request_dict = {
-        'name': 'region',
-        'method': 'PUT',
-        'body': {
-            'regions': [
-                rgs.GLOBAL,
-                rgs.EQUATORIAL,
-                rgs.NORTH_HEMIS,
-                rgs.SOUTH_HEMIS,
-                rgs.TROPICS,
-                rgs.GLOBAL
-            ]
-        }
-    }
-
-    rr = RegionRequest(request_dict)
-    print(f'rr_prep: {rr}')
-    
-    for name in rr.region_names:
-        print(f'region: {name}')
-
-# def test_get_all_records_param_check():
-#     params_forced_true = [
-#         {'all': True},
-#         {'all': 'true'},
-#         {'all': 'TRUE'},
-#         {'all': 't'},
-#         {'all': 'T'},
-#         {'all': 'yes'},
-#         {'all': 'YES'},
-#         {'all': 'Y'}
-#     ]
-
-#     for params in params_forced_true:
-#         print(f'params: {params}')
-#         assert rgs.get_all_records(params)
-    
-#     params_forced_false = [
-#         {},
-#         {'all': 0},
-#         {'all': 'F'},
-#         {'all': 'no'},
-#         {'all': 'N'}
-#     ]
-
-#     for params in params_forced_false:
-#         assert not rgs.get_all_records(params)
-
-    
-#     params_forced_invalid = [
-#         {'all': 'dude'},
-#         {'all': []},
-#         {'all': {}},
-#     ]
-
-#     for params in params_forced_invalid:
-#         with pytest.raises(ValueError):
-#             rgs.get_all_records(params)
-
-
 def test_request_put_regions():
     request_dict = {
         'name': 'region',
@@ -169,11 +106,10 @@ def test_request_put_regions():
             'regions': [
                 rgs.GLOBAL,
                 rgs.EQUATORIAL,
-                rgs.NORTH_HEMIS,
-                rgs.SOUTH_HEMIS,
+                rgs.NORTH_MIDLAT,
+                rgs.SOUTH_MIDLAT,
                 rgs.TROPICS,
                 rgs.GLOBAL,
-                rgs.TEST_SOUTH_HEMIS
             ]
         }
     }
@@ -190,8 +126,8 @@ def test_request_get_specific_regions_by_name():
             'regions': [
                 rgs.GLOBAL.get('name'),
                 rgs.EQUATORIAL.get('name'),
-                rgs.NORTH_HEMIS.get('name'),
-                rgs.SOUTH_HEMIS.get('name'),
+                rgs.NORTH_MIDLAT.get('name'),
+                rgs.SOUTH_MIDLAT.get('name'),
             ]
         }
     }
@@ -203,15 +139,7 @@ def test_request_get_specific_regions_by_region_data():
     request_dict = {
         'name': 'region',
         'method': 'GET',
-        'params': {'filter_type': 'by_data'},
-        'body': {
-            'regions': [
-                rgs.GLOBAL,
-                rgs.EQUATORIAL,
-                rgs.NORTH_HEMIS,
-                rgs.SOUTH_HEMIS,
-            ]
-        }
+        'params': {'filter_type': 'by_data', 'filters': {'min_lon': 0.0},},
     }
 
     rr = RegionRequest(request_dict)
@@ -227,8 +155,8 @@ def test_request_all_regions():
             'regions': [
                 rgs.GLOBAL,
                 rgs.EQUATORIAL,
-                rgs.NORTH_HEMIS,
-                rgs.SOUTH_HEMIS,
+                rgs.NORTH_MIDLAT,
+                rgs.SOUTH_MIDLAT,
             ]
         }
     }

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -18,11 +18,11 @@ import db_utils
 from score_db_base import handle_request
 
 #test regions
-EQUATORIAL = {'name': 'equatorial', 'min_lat': -5.0, 'max_lat': 5.0, 'min_lon': 0.0, 'max_lon': 360.0}
-GLOBAL = {'name': 'global', 'min_lat': -90.0, 'max_lat': 90.0, 'min_lon': 0.0, 'max_lon': 360.0}
-NORTH_MIDLAT = {'name': 'north_midlatitudes', 'min_lat': 20.0, 'max_lat': 60.0, 'min_lon': 0.0, 'max_lon': 360.0}
-TROPICS = {'name': 'tropics', 'min_lat': -20.0, 'max_lat': 20.0, 'min_lon': 0.0, 'max_lon': 360.0}
-SOUTH_MIDLAT = {'name': 'south_midlatitudes', 'min_lat': -60.0, 'max_lat': -20.0, 'min_lon': 0.0, 'max_lon': 360.0}
+EQUATORIAL = {'name': 'equatorial', 'min_lat': -5.0, 'max_lat': 5.0, 'east_lon': 0.0, 'west_lon': 360.0}
+GLOBAL = {'name': 'global', 'min_lat': -90.0, 'max_lat': 90.0, 'east_lon': 0.0, 'west_lon': 360.0}
+NORTH_MIDLAT = {'name': 'north_midlatitudes', 'min_lat': 20.0, 'max_lat': 60.0, 'east_lon': 0.0, 'west_lon': 360.0}
+TROPICS = {'name': 'tropics', 'min_lat': -20.0, 'max_lat': 20.0, 'east_lon': 0.0, 'west_lon': 360.0}
+SOUTH_MIDLAT = {'name': 'south_midlatitudes', 'min_lat': -60.0, 'max_lat': -20.0, 'east_lon': 0.0, 'west_lon': 360.0}
 
 def test_validate_list_of_strings():
     with pytest.raises(TypeError):
@@ -147,7 +147,7 @@ def test_request_get_specific_regions_by_region_data():
     request_dict = {
         'name': 'region',
         'method': db_utils.HTTP_GET,
-        'params': {'filter_type': 'by_data', 'filters': {'min_lon': 0.0},},
+        'params': {'filter_type': 'by_data', 'filters': {'east_lon': 0.0},},
     }
 
     rr = RegionRequest(request_dict)

--- a/tests/test_regions_module.py
+++ b/tests/test_regions_module.py
@@ -106,6 +106,28 @@ def test_validate_body():
         assert regions.count(region) == 1
         assert isinstance(region, RegionData)
 
+def test_initialize_region_request_prep():
+    request_dict = {
+        'name': 'region',
+        'method': 'PUT',
+        'body': {
+            'regions': [
+                GLOBAL,
+                EQUATORIAL,
+                NORTH_MIDLAT,
+                SOUTH_MIDLAT,
+                TROPICS,
+                GLOBAL
+            ]
+        }
+    }
+
+    rr = RegionRequest(request_dict)
+    print(f'rr_prep: {rr}')
+
+    for name in rr.region_names:
+        print(f'region: {name}')
+
 def test_request_put_regions():
     request_dict = {
         'name': 'region',


### PR DESCRIPTION
Previously, the regions table was storing values as a string of points to create the bounds which made searching and comparing more complicated and did not allow inputs of longitudes. To improve flexibility for upcoming metric types, this PR changes the regions table to use numeric separated values for each column and includes min and max lat and east and west lon. Per recommendations from Adam, the longitude is defined by an east and west boundary with value ranges between 0 to 360 to allow flexibility to the user and keep consistency in the table values. 

Changes:
* change table structure
* update calls in the regions.py file for get and put to reflect the new table structure while maintaining the existing functionality (i.e. input multiple regions at once and specific filter types) 
* update references to regions in expt_metrics as necessary
* update test file
* completed some cleanup of the regions files to use the new db_utils

note: some of the structural changes to calls, (like a separate put_regions function) reflect the structure of other files in the repo for consistency.

All tests have been run successfully. 