### PR TITLE
Feature/add long_name column

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ metric_types
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(128), nullable=False)
+    long_name = Column(String(128))
     measurement_type = Column(String(64), nullable=False)
     measurement_units = Column(String(64))
     stat_type = Column(String(64))
@@ -704,6 +705,9 @@ request_dict = {
                 'stat_type': {
                     'exact': 'rmsd'
                 },
+                'long_name': {
+                    'exact': 'rmsd of innov stats temperature'
+                }
             },
             'ordering': [
                 {'name': 'name', 'order_by': 'desc'},
@@ -721,6 +725,7 @@ request_types = {
         'method': 'PUT',
         'body' : {
             'name': name,
+            'long_name': long_name,
             'measurement_type': measurement_type,
             'measurement_units': units,
             'stat_type': stat_type,

--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -77,6 +77,7 @@ ExptMetricsData = namedtuple(
         'expt_name',
         'wallclock_start',
         'metric_id',
+        'metric_long_name',
         'metric_type',
         'metric_unit',
         'metric_stat_type',
@@ -244,6 +245,14 @@ def get_metric_types_filter(filter_dict, constructed_filter):
         'name',
         constructed_filter,
         'metric_type_name'
+    )
+
+    constructed_filter = get_string_filter(
+        filter_dict,
+        mts,
+        'long_name',
+        constructed_filter,
+        'metric_type_long_name'
     )
     
     constructed_filter = get_string_filter(
@@ -629,6 +638,7 @@ class ExptMetricRequest:
                 expt_name=metric.experiment.name,
                 wallclock_start=metric.experiment.wallclock_start,
                 metric_id=metric.metric_type.id,
+                metric_long_name=metric.metric_type.long_name,
                 metric_type=metric.metric_type.measurement_type,
                 metric_unit=metric.metric_type.measurement_units,
                 metric_stat_type=metric.metric_type.stat_type,

--- a/src/metric_types.py
+++ b/src/metric_types.py
@@ -30,7 +30,7 @@ MetricTypeData = namedtuple(
     'MetricTypeData',
     [
         'name',
-        'long_name'
+        'long_name',
         'measurement_type',
         'measurement_units',
         'stat_type',

--- a/src/metric_types.py
+++ b/src/metric_types.py
@@ -30,6 +30,7 @@ MetricTypeData = namedtuple(
     'MetricTypeData',
     [
         'name',
+        'long_name'
         'measurement_type',
         'measurement_units',
         'stat_type',
@@ -41,6 +42,7 @@ MetricTypeData = namedtuple(
 class MetricType:
     ''' metric type object storing data related to the measurement type '''
     name: str
+    long_name: str
     measurement_type: str
     measurement_units: str
     stat_type: str
@@ -52,6 +54,7 @@ class MetricType:
         print(f'description: {self.description}')
         self.metric_type_data = MetricTypeData(
             self.name,
+            self.long_name,
             self.measurement_type,
             self.measurement_units,
             self.stat_type,
@@ -81,6 +84,7 @@ def get_metric_type_from_body(body):
 
     metric_type = MetricType(
         body.get('name'),
+        body.get('long_name'),
         body.get('measurement_type'),
         body.get('measurement_units'),
         body.get('stat_type'),
@@ -120,6 +124,9 @@ def construct_filters(filters):
 
     constructed_filter = get_string_filter(
         filters, mt, 'name', constructed_filter)
+    
+    constructed_filter = get_string_filter(
+        filters, mt, 'long_name', constructed_filter)
 
     constructed_filter = get_string_filter(
         filters, mt, 'measurement_type', constructed_filter)
@@ -217,6 +224,7 @@ class MetricTypeRequest:
 
         insert_stmt = insert(mt).values(
             name=self.metric_type_data.name,
+            long_name = self.metric_type_data.long_name,
             measurement_type=self.metric_type_data.measurement_type,
             measurement_units=self.metric_type_data.measurement_units,
             stat_type=self.metric_type_data.stat_type,
@@ -232,6 +240,7 @@ class MetricTypeRequest:
             constraint='unique_metric_type',
             set_=dict(
                 # group_id=self.experiment_data.group_id,
+                long_name=self.metric_type_data.long_name, 
                 measurement_units=self.metric_type_data.measurement_units,
                 stat_type=self.metric_type_data.stat_type,
                 description=self.metric_type_data.description,
@@ -287,6 +296,7 @@ class MetricTypeRequest:
         q = session.query(
             mt.id,
             mt.name,
+            mt.long_name,
             mt.measurement_type,
             mt.measurement_units,
             mt.stat_type,

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -155,6 +155,7 @@ class MetricType(Base):
     
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String(128), nullable=False)
+    long_name = Column(String(128))
     measurement_type = Column(String(64), nullable=False)
     measurement_units = Column(String(64))
     stat_type = Column(String(64))

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -212,6 +212,9 @@ def test_send_get_request():
                 'stat_type': {
                     'exact': 'rmsd'
                 },
+                'long_name': {
+                    'exact': 'rmsd of innov stats temperature'
+                }
             },
             'ordering': [
                 {'name': 'name', 'order_by': 'desc'},

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -23,6 +23,7 @@ MetricType = namedtuple(
     'MetricType',
     [
         'name',
+        'long_name',
         'type',
         'units',
         'stat_type',
@@ -75,6 +76,7 @@ def test_parse_request_dict():
     metric_types = [
         MetricType(
             'innov_stats_temperature_count',
+            'count of innov stats temperature',
             'temperature',
             'kelvin',
             'count',
@@ -82,6 +84,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_temperature_bias',
+            'bias of innov stats temperature',
             'temperature',
             'kelvin',
             'bias',
@@ -89,6 +92,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_temperature_rmsd',
+            'rmsd of innov stats temperature',
             'temperature',
             'kelvin',
             'rmsd',
@@ -96,6 +100,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_uvwind_rmsd',
+            'rmsd of innov stats uvwind',
             'uvwind',
             'kph',
             'rmsd',
@@ -103,6 +108,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_uvwind_count',
+            'count of innov stats uvwind',
             'uvwind',
             'kph',
             'count',
@@ -110,6 +116,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_uvwind_bias',
+            'bias of innov stats uvwind',
             'uvwind',
             'kph',
             'bias',
@@ -117,6 +124,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_spechumid_rmsd',
+            'rmsd of innov stats spechumid',
             'spechumid',
             'grams of water vapor per cubic meter volume of air',
             'rmsd',
@@ -124,6 +132,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_spechumid_count',
+            'count of innov stats spechumid',
             'spechumid',
             'grams of water vapor per cubic meter volume of air',
             'count',
@@ -131,6 +140,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_spechumid_bias',
+            'bias of innov stats spechumid',
             'spechumid',
             'grams of water vapor per cubic meter volume of air',
             'bias',
@@ -138,6 +148,7 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_salinity_bias',
+            'bias of innov stats salinity',
             'salinity',
             'practical salinity',
             'bias',
@@ -145,13 +156,15 @@ def test_parse_request_dict():
         ),
         MetricType(
             'innov_stats_salinity_rmsd',
+            'rmsd of innov stats salinity',
             'salinity',
             'practical salinity',
             'rmsd',
             description_temperature_rmsd
         ),
         MetricType(
-            'mean_o3mr_inc',
+            'mean_o3mr_inc_test',
+            'test for mean_o3mr_inc',
             'test',
             'test',
             'mean',
@@ -165,6 +178,7 @@ def test_parse_request_dict():
             'method': 'PUT',
             'body': {
                 'name': m_type.name,
+                'long_name': m_type.long_name,
                 'measurement_type': m_type.type,
                 # 'measurement_units': 'grams of water vapor per cubic meter volume of air',
                 'measurement_units': m_type.units,


### PR DESCRIPTION
Add a long_name column to metric_types for easy storage and access of full length names, adds the necessary code for input and retrieval into the column. Updates the tests and all are passing as expected. Confirmed put and get with data in the database as well. 