### PR TITLE
Feature/add precip hv translator

### DIFF
--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -44,11 +44,12 @@ precip_harvested_data = namedtuple(
      'HarvestedData', 
      [
       'filenames',
-      'date',
       'statistic',
       'variable',
       'value',
-      'units'
+      'units',
+      'mediantime',
+      'longname'
       ]
 )
 """
@@ -74,7 +75,7 @@ def precip_translator(harvested_data):
             None,
             'N/A'
             harvested_data.value,
-            harvested_data.date,
+            harvested_data.mediantime,
             None,
             None
     )        

--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -37,9 +37,9 @@ def inc_logs_translator(harvested_data):
                        'global',
                        None,
                        'N/A',
-                       harvested_data.value, 
+                       harvested_data.value,
                        harvested_data.cycletime,
-                       None, 
+                       None,
                        None)
     return result
 
@@ -60,7 +60,7 @@ def precip_translator(harvested_data):
                        harvested_data.statistic + "_" + harvested_data.variable,
                        'global',
                        None,
-                       'N/A'
+                       'N/A',
                        harvested_data.value,
                        harvested_data.mediantime,
                        None,

--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -38,7 +38,21 @@ inc_logs_harvested_data = namedtuple(
         'units'
     ]
 )
+
+Expected output from precip harvester
+precip_harvested_data = namedtuple(
+     'HarvestedData', 
+     [
+      'filenames',
+      'date',
+      'statistic',
+      'variable',
+      'value',
+      'units'
+      ]
+)
 """
+
 def inc_logs_translator(harvested_data):
     result = MetricTableData(
         harvested_data.statistic + "_" + harvested_data.variable,
@@ -50,5 +64,18 @@ def inc_logs_translator(harvested_data):
         None, 
         None
     )
+    return result
 
+
+def precip_translator(harvested_data):
+    result = MetricTableData(
+            harvested_data.statistic + "_" + harvested_data.variable,
+            'global',
+            None,
+            'N/A'
+            harvested_data.value,
+            harvested_data.date,
+            None,
+            None
+    )        
     return result

--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -1,82 +1,68 @@
-"""
-Copyright 2023 NOAA
+"""Copyright 2023 NOAA
 All rights reserved.
 
 Collection of methods to translate results from harvesters
 into input data relevant for storage in the columns defined in
-the db table models. 
-
+the db table models.
 """
 
 from collections import namedtuple
 
-#data structure for what is stored in the database, corresponds to the db columns
-MetricTableData = namedtuple(
-    'MetricData',
-    [
-        'name',
-        'region_name',
-        'elevation',
-        'elevation_unit',
-        'value',
-        'cycletime',
-        'forecast_hour',
-        'ensemble_member'
-    ],
-)
-
+"""MetricTableData defines the data structure for what is stored in the 
+database, which corresponds to the db columns.
 """
-Expected output from inc_logs harvester 
-inc_logs_harvested_data = namedtuple(
-    'HarvestedData',
-    [
-        'logfile',
-        'cycletime',
-        'statistic',
-        'variable',
-        'value',
-        'units'
-    ]
-)
 
-Expected output from precip harvester
-precip_harvested_data = namedtuple(
-     'HarvestedData', 
-     [
-      'filenames',
-      'statistic',
-      'variable',
-      'value',
-      'units',
-      'mediantime',
-      'longname'
-      ]
-)
-"""
+MetricTableData = namedtuple('MetricData', ['name',
+                                            'region_name',
+                                            'elevation',
+                                            'elevation_unit',
+                                            'value',
+                                            'cycletime',
+                                            'forecast_hour', 
+                                            'ensemble_member'])
 
 def inc_logs_translator(harvested_data):
+    """Expected output from inc_logs harvester:
+    
+    inc_logs_harvested_data = namedtuple('HarvestedData', ['logfile',
+                                                           'cycletime',
+                                                           'statistic',
+                                                           'variable',
+                                                           'value',
+                                                           'units'])
+    """
+    
     result = MetricTableData(
-        harvested_data.statistic + "_" + harvested_data.variable,
-        'global',
-        None,
-        'N/A',
-        harvested_data.value, 
-        harvested_data.cycletime,
-        None, 
-        None
-    )
+                       harvested_data.statistic + "_" + harvested_data.variable,
+                       'global',
+                       None,
+                       'N/A',
+                       harvested_data.value, 
+                       harvested_data.cycletime,
+                       None, 
+                       None)
     return result
 
 
 def precip_translator(harvested_data):
+    """Expected output from precip harvester:
+        
+    precip_harvested_data = namedtuple('HarvestedData', ['filenames',
+                                                         'statistic',
+                                                         'variable',
+                                                         'value',
+                                                         'units',
+                                                         'mediantime',
+                                                         'longname'])
+    """
+    
     result = MetricTableData(
-            harvested_data.statistic + "_" + harvested_data.variable,
-            'global',
-            None,
-            'N/A'
-            harvested_data.value,
-            harvested_data.mediantime,
-            None,
-            None
-    )        
+                       harvested_data.statistic + "_" + harvested_data.variable,
+                       'global',
+                       None,
+                       'N/A'
+                       harvested_data.value,
+                       harvested_data.mediantime,
+                       None,
+                       None)        
     return result

--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -25,36 +25,20 @@ MetricTableData = namedtuple(
     ],
 )
 
-"""
-Expected output from inc_logs harvester 
-inc_logs_harvested_data = namedtuple(
-    'HarvestedData',
-    [
-        'logfile',
-        'cycletime',
-        'statistic',
-        'variable',
-        'value',
-        'units'
-    ]
-)
-
-Expected output from precip harvester
-precip_harvested_data = namedtuple(
-     'HarvestedData', 
-     [
-      'filenames',
-      'statistic',
-      'variable',
-      'value',
-      'units',
-      'mediantime',
-      'longname'
-      ]
-)
-"""
-
 def inc_logs_translator(harvested_data):
+    """ Expected output from inc_logs harvester 
+    inc_logs_harvested_data = namedtuple(
+        'HarvestedData',
+        [
+            'logfile',
+            'cycletime',
+            'statistic',
+            'variable',
+            'value',
+            'units'
+        ]
+    )
+    """
     result = MetricTableData(
         harvested_data.statistic + "_" + harvested_data.variable,
         'global',
@@ -67,13 +51,26 @@ def inc_logs_translator(harvested_data):
     )
     return result
 
-
 def precip_translator(harvested_data):
+    """ Expected output from precip harvester
+    precip_harvested_data = namedtuple(
+        'HarvestedData', 
+        [
+            'filenames',
+            'statistic',
+            'variable',
+            'value',
+            'units',
+            'mediantime',
+            'longname'
+        ]
+    )
+    """
     result = MetricTableData(
             harvested_data.statistic + "_" + harvested_data.variable,
             'global',
             None,
-            'N/A'
+            'N/A',
             harvested_data.value,
             harvested_data.mediantime,
             None,

--- a/src/harvest_translator.py
+++ b/src/harvest_translator.py
@@ -49,9 +49,9 @@ def inc_logs_translator(harvested_data):
         None)
     return result
 
-def precip_translator(harvested_data):
-    """ Expected output from precip harvester
-    precip_harvested_data = namedtuple(
+def daily_bfg_translator(harvested_data):
+    """ Expected output from daily bfg harvester
+    daily_bfg_harvested_data = namedtuple(
         'HarvestedData', 
         [
             'filenames',

--- a/src/hv_translator_registry.py
+++ b/src/hv_translator_registry.py
@@ -24,9 +24,9 @@ translator_registry = {
         'translate harvest values from inc_logs harvester',
         harvest_translator.inc_logs_translator
     ),
-    'precip': TranslatorHandler(
-        'translate harvest values from precip harvester',
-        harvest_translator.precip_translator
+    'daily_bfg': TranslatorHandler(
+        'translate harvest values from daily bfg harvester',
+        harvest_translator.daily_bfg_translator
     ),
 }
 

--- a/src/hv_translator_registry.py
+++ b/src/hv_translator_registry.py
@@ -24,6 +24,10 @@ translator_registry = {
         'translate harvest values from inc_logs harvester',
         harvest_translator.inc_logs_translator
     ),
+    'precip': TranslatorHandler(
+        'translate harvest values from precip harvester',
+        harvest_translator.precip_translator
+    ),   
 }
 
 valid_translators = list(translator_registry.keys())

--- a/src/hv_translator_registry.py
+++ b/src/hv_translator_registry.py
@@ -1,34 +1,24 @@
-"""
-Copyright 2023 NOAA
+"""Copyright 2023 NOAA
 All rights reserved.
 
 Collection translator handlers registrations.  This module helps define
 the translator handler format as well as the module definitions for each
 translator type
-
 """
 
 from collections import namedtuple
 import harvest_translator
 
-TranslatorHandler = namedtuple(
-    'TranslatorHandler',
-    [
-        'description',
-        'translate'
-    ],
-)
+TranslatorHandler = namedtuple('TranslatorHandler', ['description', 
+                                                     'translate'],)
 
-translator_registry = {
-    'inc_logs': TranslatorHandler(
-        'translate harvest values from inc_logs harvester',
-        harvest_translator.inc_logs_translator
-    ),
-    'precip': TranslatorHandler(
-        'translate harvest values from precip harvester',
-        harvest_translator.precip_translator
-    ),   
-}
+translator_registry = {'inc_logs': TranslatorHandler(
+                                        'translate harvest values from ' 
+                                        'inc_logs harvester',
+                                        harvest_translator.inc_logs_translator),
+                       'precip': TranslatorHandler(
+                                        'translate harvest values from precip '
+                                        ' harvester',
+                                        harvest_translator.precip_translator),}
 
 valid_translators = list(translator_registry.keys())
-

--- a/src/hv_translator_registry.py
+++ b/src/hv_translator_registry.py
@@ -1,24 +1,33 @@
-"""Copyright 2023 NOAA
+"""
+Copyright 2023 NOAA
 All rights reserved.
 
 Collection translator handlers registrations.  This module helps define
 the translator handler format as well as the module definitions for each
 translator type
+
 """
 
 from collections import namedtuple
 import harvest_translator
 
-TranslatorHandler = namedtuple('TranslatorHandler', ['description', 
-                                                     'translate'],)
+TranslatorHandler = namedtuple(
+    'TranslatorHandler',
+    [
+        'description',
+        'translate'
+    ],
+)
 
-translator_registry = {'inc_logs': TranslatorHandler(
-                                        'translate harvest values from ' 
-                                        'inc_logs harvester',
-                                        harvest_translator.inc_logs_translator),
-                       'precip': TranslatorHandler(
-                                        'translate harvest values from precip '
-                                        ' harvester',
-                                        harvest_translator.precip_translator),}
+translator_registry = {
+    'inc_logs': TranslatorHandler(
+        'translate harvest values from inc_logs harvester',
+        harvest_translator.inc_logs_translator
+    ),
+    'precip': TranslatorHandler(
+        'translate harvest values from precip harvester',
+        harvest_translator.precip_translator
+    ),
+}
 
 valid_translators = list(translator_registry.keys())


### PR DESCRIPTION
This PR brings in the translator needed to process requests for global mean precipitation (calculated within score-hv). Specific changes include:

- Additions to the harvest_translator docstring that show the expected output from score-hv
- The precip translator function
- The corresponding entry to the hv_translator_registry