### PR TITLE
feature: Array support 

### DIFF
--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -45,7 +45,7 @@ ArrayMetricTypeData = namedtuple(
     ],
 )
 
-class ArrayMetricsError(Exception):
+class ArrayMetricTypeError(Exception):
     def __init__(self, m):
         self.message = m
     def __str__(self):
@@ -265,19 +265,19 @@ def get_sat_meta_id(body):
             records = results.details.get('records')
             if records is None:
                 msg = 'Request for sat meta record did not return a record'
-                raise ArrayMetricsError(msg)
+                raise ArrayMetricTypeError(msg)
             record_cnt = records.shape[0]
         else:
             msg = f'Problems encountered requesting sat meta data.'
             # create error return db_action_response
-            raise ArrayMetricsError(msg)
+            raise ArrayMetricTypeError(msg)
         if record_cnt <= 0:
             msg = 'Request for sat meta record did not return a record'
-            raise ArrayMetricsError(msg)
+            raise ArrayMetricTypeError(msg)
         
     except Exception as err:
         msg = f'Problems encountered requesting sat meta data. err - {err}'
-        raise ArrayMetricsError(msg)
+        raise ArrayMetricTypeError(msg)
         
     try:
         sat_meta_id = records[sm.id.name].iat[0]
@@ -285,7 +285,7 @@ def get_sat_meta_id(body):
         error_msg = f'Problem finding sat meta id from record: {records} ' \
             f'- err: {err}'
         print(f'error_msg: {error_msg}')
-        raise ArrayMetricsError(error_msg) 
+        raise ArrayMetricTypeError(error_msg) 
     return sat_meta_id
 
 @dataclass

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -167,7 +167,7 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
         raise TypeError(msg)
 
     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-    string_flt = filter_dict.get(key)
+    string_flt = filter_dict.get(key_name)
     print(f'string_flt: {string_flt}')
 
     if string_flt is None:
@@ -177,12 +177,12 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
     like_filter = string_flt.get('like')
     # prefer like search over exact match if both exist
     if like_filter is not None:
-        constructed_filter[key_name] = (getattr(cls, key).like(like_filter))
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).like(like_filter))
         return constructed_filter
 
     exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
     if exact_match_filter is not None:
-        constructed_filter[key_name] = (getattr(cls, key).in_(exact_match_filter))
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).in_(exact_match_filter))
 
     return constructed_filter
 

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -244,7 +244,7 @@ def get_sat_meta_id(body):
                 'sat_id': {
                     'exact': sat_id
                 },
-                'sat_channel':{
+                'channel':{
                     'exact': sat_channel
                 }
             },

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -1,0 +1,283 @@
+"""
+Copyright NOAA 2024
+All rights reserved.
+
+Collection of methods to facilitate interactions with the array metric types table. 
+"""
+
+from collections import namedtuple
+import copy
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
+import pprint
+from db_action_response import DbActionResponse
+import score_table_models as stm
+from score_table_models import ArrayMetricType as amt
+from score_table_models import SatMeta as sm
+import time_utils
+import db_utils
+import numpy as np
+
+from pandas import DataFrame 
+import sqlalchemy as db
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.inspection import inspect
+from sqlalchemy import and_, or_, not_
+from sqlalchemy import asc, desc
+from sqlalchemy.sql import func
+
+ArrayMetricTypeData = namedtuple(
+    'ArrayMetricTypeData',
+    [
+        'name',
+        'long_name',
+        'sat_meta_name',
+        'obs_platform',
+        'measurement_type',
+        'measurement_units',
+        'stat_type',
+        'array_coords_labels',
+        'array_coord_units',
+        'array_index_values',
+        'array_dimensions',
+        'description',
+    ],
+)
+
+@dataclass
+class ArrayMetricType:
+    '''array metric type object for storing type data'''
+    name: str
+    long_name: str
+    sat_meta_name: str
+    obs_platform: str
+    measurement_type: str
+    measurement_units: str
+    stat_type: str
+    array_coord_labels: np.ndarray = field(init=False)
+    array_coord_units: np.ndarray = field(init=False)
+    array_index_values: np.ndarray = field(init=False)
+    array_dimensions: np.ndarray = field(init=False)
+    description: dict
+    array_metric_type_data: ArrayMetricTypeData = field(init=False)
+
+    def __post_init__(self):
+        self.array_metric_type_data = ArrayMetricTypeData(
+            self.name,
+            self.long_name,
+            self.sat_meta_name,
+            self.obs_platform,
+            self.measurement_type,
+            self.measurement_units,
+            self.stat_type,
+            self.array_coord_labels,
+            self.array_coord_units,
+            self.array_index_values,
+            self.array_dimensions,
+            self.description
+        )
+
+    def __repr__(self):
+        return f'array_metric_type_data: {self.array_metric_type_data}'
+    
+    def get_array_metric_type_data(self):
+        return self.array_metric_type_data
+    
+def get_array_metric_type_from_body(body):
+    if not isinstance(body, dict):
+        msg = 'The \'body\' key must be a type dict, was ' \
+            f'{type(body)}'
+        raise TypeError(msg)
+    
+    try:
+        description = json.loads(body.get('description'))
+    except Exception as err:
+        msg = 'Error loading \'description\', must be valid JSON - err: {err}'
+        raise ValueError(msg) from err
+    
+    try:
+        array_coord_labels = np.array(body.get('array_coord_labels'))
+    except Exception as err:
+        msg = 'Error loading \'array_coord_labels\', must be valid array - err: {err}'
+        raise ValueError(msg) from err
+    
+    try:
+        array_coord_units = np.array(body.get('array_coord_units'))
+    except Exception as err:
+        msg = 'Error loading \'array_coord_units\', must be valid array - err: {err}'
+        raise ValueError(msg) from err
+    
+    try:
+        array_index_values = np.array(body.get('array_index_values'))
+    except Exception as err:
+        msg = 'Error loading \'array_index_values\', must be valid array - err: {err}'
+        raise ValueError(msg) from err
+
+    try:
+        array_dimensions = np.array(body.get('array_dimensions'))
+    except Exception as err:
+        msg = 'Error loading \'array_dimensions\', must be valid array - err: {err}'
+        raise ValueError(msg) from err
+
+    array_metric_type = ArrayMetricType(
+        body.get('name'),
+        body.get('long_name'),
+        body.get('sat_meta_name'),
+        body.get('obs_platform'),
+        body.get('measurement_type'),
+        body.get('measurement_units'),
+        body.get('stat_type'),
+        array_coord_labels,
+        array_coord_units,
+        array_index_values,
+        array_dimensions,
+        description
+    )
+
+    return array_metric_type
+
+
+def validate_list_of_strings(values):
+    if isinstance(values, str):
+        val_list = []
+        val_list.append(values)
+        return val_list
+
+    if not isinstance(values, list):
+        msg = f'string values must be a list, was: {type(values)}'
+        raise TypeError(msg)
+    
+    for value in values:
+        if not isinstance(value, str):
+            msg = 'all values must be string type - value: ' \
+                f'{value} is type: {type(value)}'
+            raise TypeError(msg)
+    
+    return values
+
+def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    string_flt = filter_dict.get(key)
+    print(f'string_flt: {string_flt}')
+
+    if string_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    like_filter = string_flt.get('like')
+    # prefer like search over exact match if both exist
+    if like_filter is not None:
+        constructed_filter[key_name] = (getattr(cls, key).like(like_filter))
+        return constructed_filter
+
+    exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
+    if exact_match_filter is not None:
+        constructed_filter[key_name] = (getattr(cls, key).in_(exact_match_filter))
+
+    return constructed_filter
+
+
+def construct_filters(filters):
+    constructed_filter = {}
+
+    constructed_filter = get_string_filter(filters, amt, 'name', constructed_filter, 'name')
+    
+    constructed_filter = get_string_filter(filters, amt, 'long_name', constructed_filter, 'long_name')
+    
+    constructed_filter = get_string_filter(filters, amt, 'obs_platform', constructed_filter, 'obs_platform')
+
+    constructed_filter = get_string_filter(filters, amt, 'measurement_type', constructed_filter, 'measurement_type')
+
+    constructed_filter = get_string_filter(filters, amt, 'measurement_units', constructed_filter, 'measurement_units')
+
+    constructed_filter = get_string_filter(filters, amt, 'stat_type', constructed_filter, 'stat_type')
+    
+    constructed_filter = get_string_filter(filters, sm, 'name', constructed_filter, 'sat_meta_name')
+    
+    return constructed_filter
+
+def get_all_array_metric_types():
+    request_dict = {
+        'name': 'array_metric_type',
+        'method': 'GET'
+    }
+
+    amtr = ArrayMetricTypeRequest(request_dict)
+    return amtr.submit()
+
+
+@dataclass
+class ArrayMetricTypeRequest:
+    request_dict: dict
+    method: str = field(default_factory=str, init=False)
+    params: dict = field(default_factory=dict, init=False)
+    filters: dict = field(default_factory=dict, init=False)
+    ordering: list = field(default_factory=list, init=False)
+    record_limit: int = field(default_factory=int, init=False)
+    body: dict = field(default_factory=dict, init=False)
+    array_metric_type: ArrayMetricType = field(init=False)
+    array_metric_type_data: namedtuple = field(init=False)
+    response: dict = field(default_factory=dict, init=False)
+
+    def __post_init__(self):
+        self.method = db_utils.validate_method(self.request_dict.get('method'))
+        self.params = self.request_dict.get('params')
+
+        self.body = self.request_dict.get('body')
+        if self.method == db_utils.HTTP_PUT:
+            self.array_metric_type = get_array_metric_type_from_body(self.body)
+            self.array_metric_type_data = self.array_metric_type.get_array_metric_type_data()
+            # for k, v in zip(
+            #     self.array_metric_type_data._fields, self.array_metric_type_data
+            # ):
+            #     val = pprint.pformat(v, indent=4)
+            #     print(f'exp_data: k: {k}, v: {val}')
+        else:
+            if isinstance(self.params, dict):
+                self.filters = construct_filters(self.params.get('filters'))
+                self.ordering = self.params.get('ordering')
+                self.record_limit = self.params.get('record_limit')
+            
+                if not type(self.record_limit) == int or self.record_limit <= 0:
+                    self.record_limit = None
+            else:
+                self.filters = None
+                self.ordering = None
+                self.record_limit = None
+
+
+    def failed_request(self, error_msg):
+        return DbActionResponse(
+            request=self.request_dict,
+            success=False,
+            message='Failed array metric type request.',
+            details=None,
+            errors=error_msg
+        )
+    
+    def submit(self):
+        if self.method == db_utils.HTTP_GET:
+            return self.get_array_metric_types()
+        elif self.method == db_utils.HTTP_PUT:
+            try:
+                return self.put_array_metric_types()
+            except Exception as err:
+                error_msg = 'Failed to insert array metric type record -' \
+                    f' err: {err}'
+                print(f'Submit PUT error: {error_msg}')
+                return self.failed_request(error_msg)
+            
+    def put_array_metric_type(self):
+        session = stm.get_session()
+
+        insert_stmt = insert(amt).values(
+            name=self.array_metric_type_data.name,
+            long_name=self.array_metric_type_data.long_name, 
+
+        )

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -18,7 +18,6 @@ from score_table_models import SatMeta as sm
 from sat_meta import SatMetaRequest
 import time_utils
 import db_utils
-import numpy as np
 
 from pandas import DataFrame 
 import sqlalchemy as db
@@ -37,7 +36,7 @@ ArrayMetricTypeData = namedtuple(
         'measurement_type',
         'measurement_units',
         'stat_type',
-        'array_coords_labels',
+        'array_coord_labels',
         'array_coord_units',
         'array_index_values',
         'array_dimensions',
@@ -60,10 +59,10 @@ class ArrayMetricType:
     measurement_type: str
     measurement_units: str
     stat_type: str
-    array_coord_labels: np.ndarray = field(init=False)
-    array_coord_units: np.ndarray = field(init=False)
-    array_index_values: np.ndarray = field(init=False)
-    array_dimensions: np.ndarray = field(init=False)
+    array_coord_labels: list
+    array_coord_units: list
+    array_index_values: list
+    array_dimensions: list
     description: dict
     array_metric_type_data: ArrayMetricTypeData = field(init=False)
 
@@ -100,42 +99,18 @@ def get_array_metric_type_from_body(body):
         msg = 'Error loading \'description\', must be valid JSON - err: {err}'
         raise ValueError(msg) from err
     
-    try:
-        array_coord_labels = np.array(body.get('array_coord_labels'))
-    except Exception as err:
-        msg = 'Error loading \'array_coord_labels\', must be valid array - err: {err}'
-        raise ValueError(msg) from err
-    
-    try:
-        array_coord_units = np.array(body.get('array_coord_units'))
-    except Exception as err:
-        msg = 'Error loading \'array_coord_units\', must be valid array - err: {err}'
-        raise ValueError(msg) from err
-    
-    try:
-        array_index_values = np.array(body.get('array_index_values'))
-    except Exception as err:
-        msg = 'Error loading \'array_index_values\', must be valid array - err: {err}'
-        raise ValueError(msg) from err
-
-    try:
-        array_dimensions = np.array(body.get('array_dimensions'))
-    except Exception as err:
-        msg = 'Error loading \'array_dimensions\', must be valid array - err: {err}'
-        raise ValueError(msg) from err
-
     array_metric_type = ArrayMetricType(
-        body.get('name'),
-        body.get('long_name'),
-        body.get('obs_platform'),
-        body.get('measurement_type'),
-        body.get('measurement_units'),
-        body.get('stat_type'),
-        array_coord_labels,
-        array_coord_units,
-        array_index_values,
-        array_dimensions,
-        description
+        name=body.get('name'),
+        long_name=body.get('long_name'),
+        obs_platform=body.get('obs_platform'),
+        measurement_type=body.get('measurement_type'),
+        measurement_units=body.get('measurement_units'),
+        stat_type=body.get('stat_type'),
+        array_coord_labels=body.get('array_coord_labels'),
+        array_coord_units=body.get('array_coord_units'),
+        array_index_values=body.get('array_index_values'),
+        array_dimensions=body.get('array_dimensions'),
+        description=description
     )
 
     return array_metric_type
@@ -241,9 +216,7 @@ def get_sat_meta_id(body):
                 'sensor': {
                     'exact': sat_sensor
                 },
-                'sat_id': {
-                    'exact': sat_id
-                },
+                'sat_id': sat_id,
                 'channel':{
                     'exact': sat_channel
                 }
@@ -339,7 +312,7 @@ class ArrayMetricTypeRequest:
             return self.get_array_metric_types()
         elif self.method == db_utils.HTTP_PUT:
             try:
-                return self.put_array_metric_types()
+                return self.put_array_metric_type()
             except Exception as err:
                 error_msg = 'Failed to insert array metric type record -' \
                     f' err: {err}'

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -216,7 +216,6 @@ def get_all_array_metric_types():
     return amtr.submit()
 
 def get_sat_meta_id(body):
-    # get sat name
     sat_meta_id = -1
     try:    
         sat_meta_name = body.get('sat_meta_name')
@@ -307,9 +306,15 @@ class ArrayMetricTypeRequest:
 
         self.body = self.request_dict.get('body')
         if self.method == db_utils.HTTP_PUT:
-            self.array_metric_type = get_array_metric_type_from_body(self.body)
-            self.array_metric_type_data = self.array_metric_type.get_array_metric_type_data()
-            self.sat_meta_id = get_sat_meta_id(self.body)
+            try:
+                self.array_metric_type = get_array_metric_type_from_body(self.body)
+                self.array_metric_type_data = self.array_metric_type.get_array_metric_type_data()
+                self.sat_meta_id = get_sat_meta_id(self.body)
+            except Exception as err:
+                error_msg = 'Failed to get array metric type information to insert -' \
+                    f' err: {err}'
+                print(f'Submit PUT error: {error_msg}')
+                return self.failed_request(error_msg)
         else:
             if isinstance(self.params, dict):
                 self.filters = construct_filters(self.params.get('filters'))

--- a/src/array_metric_types.py
+++ b/src/array_metric_types.py
@@ -398,6 +398,7 @@ class ArrayMetricTypeRequest:
     def get_array_metric_types(self):
         session = stm.get_session()
 
+        #TODO: need to do a join on sat meta info!!! going to return all of that as well and for filtering 
         q = session.query(
             amt.id,
             amt.sat_meta_id,

--- a/src/db_request_registry.py
+++ b/src/db_request_registry.py
@@ -19,6 +19,9 @@ from file_types import FileTypeRequest
 from storage_locations import StorageLocationRequest
 from expt_file_counts import ExptFileCountRequest
 from harvest_metrics import HarvestMetricsRequest
+from array_metric_types import ArrayMetricTypeRequest
+from sat_meta import SatMetaRequest
+from expt_array_metrics import ExptArrayMetricRequest
 
 NAMED_TUPLES_LIST = 'tuples_list'
 PANDAS_DATAFRAME = 'pandas_dataframe'
@@ -84,6 +87,21 @@ request_registry = {
     'harvest_metrics': RequestHandler(
         'Harvest and store metrics',
         HarvestMetricsRequest,
+        DbActionResponse
+    ),
+    'array_metric_types': RequestHandler(
+        'Add or get or update array metric types',
+        ArrayMetricTypeRequest,
+        DbActionResponse
+    ),
+    'sat_meta': RequestHandler(
+        'Add or get or update sat metadata',
+        SatMetaRequest,
+        DbActionResponse
+    ),
+    'expt_array_metrics': RequestHandler(
+        'Add or get experiment array metrics data',
+        ExptArrayMetricRequest,
         DbActionResponse
     )
 }

--- a/src/expt_array_metrics.py
+++ b/src/expt_array_metrics.py
@@ -20,7 +20,7 @@ from sqlalchemy import and_, or_, not_
 from db_action_response import DbActionResponse
 import score_table_models as stm
 from score_table_models import Experiment as exp
-from score_table_models import ArrayExperimentMetric as arr_ex_mt
+from score_table_models import ExptArrayMetric as ex_arr_mt
 from score_table_models import ArrayMetricType as amt
 from score_table_models import SatMeta as sm
 from score_table_models import Region as rgs
@@ -418,13 +418,13 @@ class ExptArrayMetricRequest:
             self.filters.get('regions'), constructed_filter)
 
         constructed_filter = get_time_filter(
-            self.filters, arr_ex_mt, 'time_valid', constructed_filter)
+            self.filters, ex_arr_mt, 'time_valid', constructed_filter)
 
-        constructed_filter = get_float_filter(self.filters, arr_ex_mt, 'forecast_hour', constructed_filter)
+        constructed_filter = get_float_filter(self.filters, ex_arr_mt, 'forecast_hour', constructed_filter)
 
-        constructed_filter = get_float_filter(self.filters, arr_ex_mt, 'ensemble_member', constructed_filter)
+        constructed_filter = get_float_filter(self.filters, ex_arr_mt, 'ensemble_member', constructed_filter)
 
-        constructed_filter = get_boolean_filter(self.filters, arr_ex_mt, 'assimilated', constructed_filter)
+        constructed_filter = get_boolean_filter(self.filters, ex_arr_mt, 'assimilated', constructed_filter)
 
         if len(constructed_filter) > 0:
             try:
@@ -481,7 +481,7 @@ class ExptArrayMetricRequest:
             if math.isnan(value):
                 value = None
             
-            item = arr_ex_mt(
+            item = ex_arr_mt(
                 experiment_id=self.expt_id,
                 array_metric_type_id=amt_df_dict[row.name],
                 region_id=rg_df_dict[row.region_name],
@@ -549,18 +549,18 @@ class ExptArrayMetricRequest:
         session = stm.get_session()
 
         q = session.query(
-            arr_ex_mt
+            ex_arr_mt
         ).join(
-            exp, arr_ex_mt.experiment
+            exp, ex_arr_mt.experiment
         ).join(
-            amt, arr_ex_mt.array_metric_type
+            amt, ex_arr_mt.array_metric_type
         ).join(
-            rgs, arr_ex_mt.region
+            rgs, ex_arr_mt.region
         )
 
         q = self.construct_filters(q)
 
-        column_ordering = db_utils.build_column_ordering(arr_ex_mt, self.ordering)
+        column_ordering = db_utils.build_column_ordering(ex_arr_mt, self.ordering)
         if column_ordering is not None and len(column_ordering) > 0:
             for ordering_item in column_ordering:
                 q = q.order_by(ordering_item)

--- a/src/expt_array_metrics.py
+++ b/src/expt_array_metrics.py
@@ -641,6 +641,7 @@ class ExptArrayMetricRequest:
 
         print(f'response: {response}')
 
+        session.close()
         return response
 
     def remove_metric_duplicates(self, m_df):

--- a/src/expt_array_metrics.py
+++ b/src/expt_array_metrics.py
@@ -371,7 +371,15 @@ class ExptArrayMetricRequest:
             self.record_limit = self.params.get('record_limit')
 
         if self.method == db_utils.HTTP_PUT:
-            self.expt_id = get_expt_record_id(self.body)
+            try:
+                self.expt_id = get_expt_record_id(self.body)
+            except Exception as err:
+                trcbk = traceback.format_exc()
+                error_msg = 'Failed to locate experiment record id necessary to insert experiment array metric record -' \
+                    f' trcbk: {trcbk}'
+                print(f'Submit PUT error: {error_msg}')
+                print(f'Error: {err}')
+                return self.failed_request(error_msg)
 
     def submit(self):
         if self.method == db_utils.HTTP_GET:

--- a/src/expt_array_metrics.py
+++ b/src/expt_array_metrics.py
@@ -1,0 +1,47 @@
+"""
+Copyright NOAA 2024
+All rights reserved.
+
+Collection of methods to facilitate handling of requests for array based experiment metrics.
+Will also interact with the experiments, regions, array metric types, and sat meta tables. 
+"""
+
+from collections import namedtuple
+import copy
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
+import math
+import pprint
+import traceback
+
+import numpy as np
+from psycopg2.extensions import register_adapter, AsIs
+from sqlalchemy import Integer, String, Boolean, DateTime, Float
+import psycopg2
+import pandas as pd
+from pandas import DataFrame
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.inspection import inspect
+from sqlalchemy import and_, or_, not_
+from sqlalchemy import asc, desc
+from sqlalchemy.sql import func
+from sqlalchemy.orm import joinedload
+
+
+from db_action_response import DbActionResponse
+import score_table_models as stm
+from score_table_models import Experiment as exp
+from score_table_models import ExperimentMetric as ex_mt
+from score_table_models import MetricType as mts
+from score_table_models import Region as rgs
+from experiments import Experiment, ExperimentData
+from experiments import ExperimentRequest
+import regions as rg
+import metric_types as mt
+import array_metric_types as amt
+import time_utils
+import db_utils
+
+psycopg2.extensions.register_adapter(np.int64, psycopg2._psycopg.AsIs)
+psycopg2.extensions.register_adapter(np.float32, psycopg2._psycopg.AsIs)

--- a/src/expt_array_metrics.py
+++ b/src/expt_array_metrics.py
@@ -32,16 +32,309 @@ from sqlalchemy.orm import joinedload
 from db_action_response import DbActionResponse
 import score_table_models as stm
 from score_table_models import Experiment as exp
-from score_table_models import ExperimentMetric as ex_mt
-from score_table_models import MetricType as mts
+from score_table_models import ArrayExperimentMetric as arr_ex_mt
+from score_table_models import ArrayMetricType as amt
+from score_table_models import SatMeta as sm
 from score_table_models import Region as rgs
 from experiments import Experiment, ExperimentData
 from experiments import ExperimentRequest
 import regions as rg
-import metric_types as mt
 import array_metric_types as amt
 import time_utils
 import db_utils
 
 psycopg2.extensions.register_adapter(np.int64, psycopg2._psycopg.AsIs)
 psycopg2.extensions.register_adapter(np.float32, psycopg2._psycopg.AsIs)
+
+ExptArrayMetricInputData = namedtuple(
+    'ExptArrayMetricInputData',
+    [
+        'value',
+        'bias_correction',
+        'assimilated',
+        'time_valid',
+        'forecast_hour',
+        'ensemble_member'
+    ],
+) 
+
+#edit as necessary for this section
+ExptArrayMetricsData = namedtuple(
+    'ExptArrayMetricsData',
+    [
+        'id',
+        'name',
+        'elevation',
+        'elevation_unit',
+        'value',
+        'bias_correction',
+        'time_valid',
+        'forecast_hour',
+        'ensemble_member',
+        'expt_id',
+        'expt_name',
+        'wallclock_start',
+        'metric_id',
+        'metric_long_name',
+        'metric_type',
+        'metric_unit',
+        'metric_stat_type',
+        'region_id',
+        'region',
+        'created_at'
+    ],
+)
+
+class ExptArrayMetricsError(Exception):
+    def __init__(self, m):
+        self.message = m
+    def __str__(self):
+        return self.message
+    
+def get_time_filter(filter_dict, cls, key, constructed_filter):
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    value = filter_dict.get(key)
+    if value is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    exact_datetime = time_utils.get_time(value.get(db_utils.EXACT_DATETIME))
+
+    if exact_datetime is not None:
+        constructed_filter[key] = (
+            getattr(cls, key) == exact_datetime
+        )
+        return constructed_filter
+
+    from_datetime = time_utils.get_time(value.get(db_utils.FROM_DATETIME))
+    to_datetime = time_utils.get_time(value.get(db_utils.TO_DATETIME))
+
+    if from_datetime is not None and to_datetime is not None:
+        if to_datetime < from_datetime:
+            raise ValueError('\'from\' must be older than \'to\'')
+        
+        constructed_filter[key] = and_(
+            getattr(cls, key) >= from_datetime,
+            getattr(cls, key) <= to_datetime
+        )
+    elif from_datetime is not None:
+        constructed_filter[key] = (
+            getattr(cls, key) >= from_datetime
+        )
+    elif to_datetime is not None:
+        constructed_filter[key] = (
+            getattr(cls, key) <= to_datetime
+        )
+
+    return constructed_filter
+
+
+def validate_list_of_strings(values):
+    if isinstance(values, str):
+        val_list = []
+        val_list.append(values)
+        return val_list
+
+    if not isinstance(values, list):
+        msg = f'string values must be a list, was: {type(values)}'
+        raise TypeError(msg)
+    
+    for value in values:
+        if not isinstance(value, str):
+            msg = 'all values must be string type - value: ' \
+                f'{value} is type: {type(value)}'
+            raise TypeError(msg)
+    
+    return values
+
+
+def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    string_flt = filter_dict.get(key)
+    print(f'string_flt: {string_flt}')
+
+    if string_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    like_filter = string_flt.get('like')
+    # prefer like search over exact match if both exist
+    if like_filter is not None:
+        constructed_filter[key_name] = (getattr(cls, key).like(like_filter))
+        return constructed_filter
+
+    exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
+    if exact_match_filter is not None:
+        constructed_filter[key_name] = (getattr(cls, key).in_(exact_match_filter))
+
+    return constructed_filter
+
+def get_float_filter(filter_dict, cls, key, constructed_filter):
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    float_flt = filter_dict.get(key)
+
+    if float_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    constructed_filter[key] = ( getattr(cls, key) == float_flt )
+    
+    return constructed_filter
+
+def get_experiments_filter(filter_dict, constructed_filter):
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)   
+    
+    constructed_filter = get_string_filter(
+        filter_dict, exp, 'name', constructed_filter, 'experiment_name')
+    
+    constructed_filter = get_time_filter(
+        filter_dict, exp, 'cycle_start', constructed_filter)
+
+    constructed_filter = get_time_filter(
+        filter_dict, exp, 'cycle_stop', constructed_filter)
+
+    constructed_filter = get_time_filter(
+        filter_dict, exp, 'wallclock_start', constructed_filter)
+    
+    return constructed_filter
+
+def get_array_metric_types_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        return constructed_filter
+    
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    constructed_filter = get_string_filter(filter_dict, amt, 'name', constructed_filter, 'name')
+    
+    constructed_filter = get_string_filter(filter_dict, amt, 'long_name', constructed_filter, 'long_name')
+    
+    constructed_filter = get_string_filter(filter_dict, amt, 'obs_platform', constructed_filter, 'obs_platform')
+
+    constructed_filter = get_string_filter(filter_dict, amt, 'measurement_type', constructed_filter, 'measurement_type')
+
+    constructed_filter = get_string_filter(filter_dict, amt, 'measurement_units', constructed_filter, 'measurement_units')
+
+    constructed_filter = get_string_filter(filter_dict, amt, 'stat_type', constructed_filter, 'stat_type')
+    
+    constructed_filter = get_string_filter(filter_dict, sm, 'name', constructed_filter, 'sat_meta_name')
+
+    return constructed_filter   
+
+def get_regions_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        return constructed_filter
+
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    constructed_filter = get_string_filter(
+        filter_dict, rgs, 'name', constructed_filter, 'rgs_name')
+
+    constructed_filter = get_float_filter(filter_dict, rgs, 'min_lat', constructed_filter)
+
+    constructed_filter = get_float_filter(filter_dict, rgs, 'max_lat', constructed_filter)
+
+    constructed_filter = get_float_filter(filter_dict, rgs, 'east_lon', constructed_filter)
+
+    constructed_filter = get_float_filter(filter_dict, rgs, 'west_lon', constructed_filter)
+
+    return constructed_filter
+
+def get_expt_record_id(body):
+    expt_name = body.get('expt_name')
+    wlclk_strt_str = body.get('expt_wallclock_start')
+    
+    expt_request = {
+        'name': 'experiment',
+        'method': db_utils.HTTP_GET,
+        'params': {
+            'filters': {
+                'name': {
+                    'exact': expt_name
+                },
+                'wallclock_start': {
+                    'exact': wlclk_strt_str
+                },
+            },
+            'ordering': [
+                {'name': 'wallclock_start', 'order_by': 'desc'}
+            ],
+            'record_limit': 1
+        }
+    }
+
+    print(f'expt_request: {expt_request}')
+
+    er = ExperimentRequest(expt_request)
+
+    results = er.submit()
+    print(f'results: {results}')
+
+    record_cnt = 0
+    try:
+        if results.success is True:
+            records = results.details.get('records')
+            if records is None:
+                msg = 'Request for experiment record did not return a record'
+                raise ExptArrayMetricsError(msg)
+            record_cnt = records.shape[0]
+        else:
+            msg = f'Problems encountered requesting experiment data.'
+            # create error return db_action_response
+            raise ExptArrayMetricsError(msg)
+        if record_cnt <= 0:
+            msg = 'Request for experiment record did not return a record'
+            raise ExptArrayMetricsError(msg)
+        
+    except Exception as err:
+        msg = f'Problems encountered requesting experiment data. err - {err}'
+        raise ExptArrayMetricsError(msg)
+    
+    try:
+        experiment_id = records[exp.id.name].iat[0]
+    except Exception as err:
+        error_msg = f'Problem finding experiment id from record: {records} ' \
+            f'- err: {err}'
+        print(f'error_msg: {error_msg}')
+        raise ExptArrayMetricsError(error_msg) 
+        
+    return experiment_id
+
+##TODO: request class 

--- a/src/expt_metrics.py
+++ b/src/expt_metrics.py
@@ -565,27 +565,27 @@ class ExptMetricRequest:
         records = self.get_expt_metrics_from_body(self.body)
         session = stm.get_session()
 
-        try:
-            if len(records) > 0:
-                for record in records:
-                    msg = f'record.experiment_id: {record.experiment_id}, '
-                    msg += f'record.metric_type_id: {record.metric_type_id}, '
-                    msg += f'record.region_id: {record.region_id}, '
-                    msg += f'record.elevation: {record.elevation}, '
-                    msg += f'record.elevation_unit: {record.elevation_unit}, '
-                    msg += f'record.value: {record.value}, '
-                    msg += f'record.time_valid: {record.time_valid}, '
-                    msg += f'record.forecast_hour: {record.forecast_hour},'
-                    msg += f'record.ensemble_member: {record.ensemble_member},'
-                    msg += f'record.created_at: {record.created_at}'
-                    print(f'record: {msg}')
 
-                session.bulk_save_objects(records)
-                session.commit()
-                session.close()
+        if len(records) > 0:
+            for record in records:
+                msg = f'record.experiment_id: {record.experiment_id}, '
+                msg += f'record.metric_type_id: {record.metric_type_id}, '
+                msg += f'record.region_id: {record.region_id}, '
+                msg += f'record.elevation: {record.elevation}, '
+                msg += f'record.elevation_unit: {record.elevation_unit}, '
+                msg += f'record.value: {record.value}, '
+                msg += f'record.time_valid: {record.time_valid}, '
+                msg += f'record.forecast_hour: {record.forecast_hour},'
+                msg += f'record.ensemble_member: {record.ensemble_member},'
+                msg += f'record.created_at: {record.created_at}'
+                print(f'record: {msg}')
 
-        except Exception as err:
-            print(f'Failed to insert records: {err}')
+            session.bulk_save_objects(records)
+            session.commit()
+            session.close()
+        else:
+            session.close()
+            return self.failed_request('No expt metric records were discovered to be inserted')
 
         return DbActionResponse(
             request=self.request_dict,

--- a/src/sat_meta.py
+++ b/src/sat_meta.py
@@ -17,6 +17,10 @@ from score_table_models import SatMeta as sm
 import time_utils
 import db_utils
 
+import numpy as np
+from psycopg2.extensions import register_adapter, AsIs
+from sqlalchemy import Integer, String, Boolean, DateTime, Float
+import psycopg2
 from pandas import DataFrame
 import sqlalchemy as db
 from sqlalchemy.dialects.postgresql import insert
@@ -24,6 +28,9 @@ from sqlalchemy.inspection import inspect
 from sqlalchemy import and_, or_, not_
 from sqlalchemy import asc, desc
 from sqlalchemy.sql import func
+
+psycopg2.extensions.register_adapter(np.int64, psycopg2._psycopg.AsIs)
+psycopg2.extensions.register_adapter(np.float32, psycopg2._psycopg.AsIs)
 
 SatMetaData = namedtuple(
     'SatMetaData',

--- a/src/sat_meta.py
+++ b/src/sat_meta.py
@@ -1,0 +1,312 @@
+"""
+Copyright NOAA 2024.
+All rights reserved.
+
+Collection of methods to faciliate interactions with the sat meta table.
+"""
+
+from collections import namedtuple
+import copy
+from dataclasses import dataclass, field
+from datetime import datetime
+import json
+import pprint
+from db_action_response import DbActionResponse
+import score_table_models as stm
+from score_table_models import SatMeta as sm 
+import time_utils
+import db_utils
+
+from pandas import DataFrame
+import sqlalchemy as db
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.inspection import inspect
+from sqlalchemy import and_, or_, not_
+from sqlalchemy import asc, desc
+from sqlalchemy.sql import func
+
+SatMetaData = namedtuple(
+    'SatMetaData',
+    [
+        'sat_id',
+        'sat_name',
+        'sensor',
+        'channel',
+        'scan_angle'
+    ],
+)
+
+@dataclass
+class SatMeta:
+    '''sat meta data object'''
+    sat_id: int
+    sat_name: str
+    sensor: str
+    sensor: str
+    channel: str
+    scan_angle: str
+    sat_meta_data: SatMetaData = field(init=False)
+
+    def __post_init__(self):
+        self.sat_meta_data = SatMetaData(
+            self.sat_id,
+            self.sat_name,
+            self.sensor,
+            self.channel,
+            self.scan_angle
+        )
+
+    def __repr__(self):
+        return f'sat_meta_data: {self.sat_meta_data}'
+    
+    def get_sat_meta_data(self):
+        return self.sat_meta_data
+
+def get_sat_meta_from_body(body):
+    if not isinstance(body, dict):
+        msg = 'The \'body\' key must be a type dict, was ' \
+            f'{type(body)}'
+        raise TypeError(msg)
+    
+    sat_meta = SatMeta(
+        body.get('sat_id'),
+        body.get('sat_name'),
+        body.get('sensor'),
+        body.get('channel'),
+        body.get('scan_angle')
+    )
+    return sat_meta
+
+def get_string_filter(filters, cls, key, constructed_filter):
+    if not isinstance(filters, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filters)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    string_flt = filters.get(key)
+
+    if string_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    like_filter = string_flt.get('like')
+    # prefer like search over exact match if both exist
+    if like_filter is not None:
+        constructed_filter[key] = (getattr(cls, key).like(like_filter))
+        return constructed_filter
+
+    exact_match_filter = string_flt.get('exact')
+    if exact_match_filter is not None:
+        constructed_filter[key] = (getattr(cls, key) == exact_match_filter)
+
+    return constructed_filter
+
+def get_int_filter(filters, cls, key, constructed_filter):
+    if not isinstance(filters, dict):
+        msg = f'Invalid type for filters, must be \'dict\', was ' \
+            f'type: {type(filters)}'
+        raise TypeError(msg)
+
+    print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
+    int_flt = filters.get(key)
+
+    if int_flt is None:
+        print(f'No \'{key}\' filter detected')
+        return constructed_filter
+
+    constructed_filter[key] = ( getattr(cls, key) == int_flt )
+    
+    return constructed_filter
+
+def construct_filters(filters):
+    constructed_filter = {}
+
+    constructed_filter = get_int_filter(filters, sm, 'sat_id', constructed_filter)
+
+    constructed_filter = get_string_filter(filters, sm, 'sat_name', constructed_filter)
+
+    constructed_filter = get_string_filter(filters, sm, 'sensor', constructed_filter)
+
+    constructed_filter = get_string_filter(filters, sm, 'channel', constructed_filter)
+
+    constructed_filter = get_string_filter(filters, sm, 'scan_angle', constructed_filter)
+
+    return constructed_filter
+
+@dataclass
+class SatMetaRequest:
+    request_dict: dict
+    method: str = field(default_factory=str, init=False)
+    params: dict = field(default_factory=dict, init=False)
+    filters: dict = field(default_factory=dict, init=False)
+    ordering: list = field(default_factory=list, init=False)
+    record_limit: int = field(default_factory=int, init=False)
+    body: dict = field(default_factory=dict, init=False)
+    sat_meta: SatMeta = field(init=False)
+    response: dict = field(default_factory=dict, init=False)
+
+    def __post_init__(self):
+        self.method = db_utils.validate_method(self.request_dict.get('method'))
+        self.params = self.request_dict.get('params')
+        self.body = self.request_dict.get('body')
+        self.filters = None
+        self.ordering = None
+        self.record_limit = None
+        if self.params is not None:
+            self.filters = self.params.get('filters')
+            self.ordering = self.params.get('ordering')
+            self.record_limit = self.params.get('record_limit')
+
+    def failed_request(self, error_msg):
+        return DbActionResponse(
+            request=self.request_dict,
+            success=False,
+            message='Failed sat meta request',
+            details=None, 
+            errors=error_msg
+        )
+
+    def submit(self):
+        if self.method == db_utils.HTTP_GET:
+            self.get_sat_metas()
+        elif self.method == db_utils.HTTP_PUT:
+            try:
+                return self.put_sat_meta()
+            except Exception as err:
+                error_msg = 'Failed to insert sat meta record -'\
+                    f' err: {err}'
+                print(f'Submit PUT sat meta error: {error_msg}')
+                return self.failed_request(error_msg)
+            
+    def put_sat_meta(self):
+        session = stm.get_session()
+
+        insert_stmt = insert(sm).values(
+            sat_id = self.sat_meta.sat_id,
+            sat_name = self.sat_meta.sat_name,
+            sensor = self.sat_meta.sensor,
+            channel = self.sat_meta.channel,
+            scan_angle = self.sat_meta.scan_angle,
+            created_at = datetime.utcnow(),
+            updated_at = None
+        ).returning(sm)
+        print(f'insert stmt: {insert_stmt}')
+
+        time_now = datetime.utcnow()
+
+        #note, at this time all fields are part of constraint, no updates allowed
+        #this will just change the time but is here in the case of future fields being added
+        do_update_stmt = insert_stmt.on_conflict_do_update(
+            constraint='unique_sat_meta',
+            set_=dict(
+                updated_at = time_now
+            )
+        )
+        
+        print(f'do_update_stmt: {do_update_stmt}')
+
+        try:
+            result = session.execute(do_update_stmt)
+            session.flush()
+            result_row = result.fetchone()
+            action = db_utils.INSERT
+            if result_row.updated_at is not None:
+                action = db_utils.UPDATE
+
+            session.commit()
+            session.close()
+        except Exception as err:
+            message = f'Attempt to INSERT/UPDATE sat meta record FAILED'
+            error_msg = f'Failed to insert/update record - err: {err}'
+            print(f'error_msg: {error_msg}')
+            session.close()
+        else:
+            message = f'Attempt to {action} sat meta record SUCCEEDED'
+            error_msg = None
+        
+        results = {}
+        if result_row is not None:
+            results['action'] = action
+            results['data'] = [result_row._mapping]
+            results['id'] = result_row.id
+
+        response = DbActionResponse(
+            self.request_dict,
+            (error_msg is None),
+            message,
+            results,
+            error_msg
+        )
+
+        print(f'response: {response}')
+        return response
+    
+    def get_sat_metas(self):
+        session = stm.get_session()
+
+        q = session.query(
+            sm.id,
+            sm.sat_id,
+            sm.sat_name, 
+            sm.sensor, 
+            sm.channel,
+            sm.scan_angle,
+            sm.created_at,
+            sm.updated_at
+        ).select_from(
+            sm
+        )
+
+        print('Before adding filters to sat meta request########################')
+        if self.filters is not None and len(self.filters) > 0:
+            for key, value in self.filters.items():
+                q = q.filter(value)
+        
+        print('After adding filters to sat meta request########################')
+        
+        # add column ordering
+        column_ordering = db_utils.build_column_ordering(sm, self.ordering)
+        if column_ordering is not None and len(column_ordering) > 0:
+            for ordering_item in column_ordering:
+                q = q.order_by(ordering_item)
+
+        # limit number of returned records
+        if self.record_limit is not None and self.record_limit > 0:
+            q = q.limit(self.record_limit)
+
+        sat_metas = q.all()
+
+        results = DataFrame()
+        error_msg = None
+        record_count = 0
+        try:
+            if len(sat_metas) > 0:
+                results = DataFrame(sat_metas, columns = sat_metas[0]._fields)
+            
+        except Exception as err:
+            message = 'Request for sat meta records FAILED'
+            error_msg = f'Failed to get sat meta records - err: {err}'
+        else:
+            message = 'Request for sat meta records SUCCEEDED'
+            for idx, row in results.iterrows():
+                print(f'idx: {idx}, row: {row}')
+            record_count = len(results.index)
+        
+        details = {}
+        details['record_count'] = record_count
+
+        if record_count > 0:
+            details['records'] = results
+
+        response = DbActionResponse(
+            self.request_dict,
+            (error_msg is None),
+            message,
+            details,
+            error_msg
+        )
+
+        print(f'response: {response}')
+
+        return response

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -282,8 +282,8 @@ class ArrayMetricType(Base):
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime)
 
-    array_metrics = relationship('ExptArrayMetrics', back_populates='array_metric_type')
-    sat_meta = relationship('SatMetas', back_populates='array_metric_type')
+    array_metrics = relationship('ExptArrayMetric', back_populates='array_metric_type')
+    sat_meta = relationship('SatMeta', back_populates='array_metric_type')
 
 class SatMeta(Base):
     __tablename__ = SAT_META_TABLE

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -242,7 +242,7 @@ class ExptArrayMetric(Base):
     region_id = Column(Integer, ForeignKey('regions.id'))
     value = Column(ARRAY(Float))
     bias_correction = Column(ARRAY(Float))
-    assimiated = Column(Boolean)
+    assimilated = Column(Boolean)
     time_valid = Column(DateTime)
     forecast_hour = Column(Float)
     ensemble_member = Column(Integer)

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -267,7 +267,7 @@ class ArrayMetricType(Base):
     )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    sat_meta_id = Column(Integer, ForeignKey('sat_meta.id'))
+    sat_meta_id = Column(Integer, ForeignKey('sat_meta.id'), nullable=True)
     obs_platform = Column(String(128))
     name = Column(String(128), nullable=False)
     long_name = Column(String(128))

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -238,7 +238,7 @@ class ExptArrayMetric(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     experiment_id = Column(Integer, ForeignKey('experiments.id'))
-    array_type_id = Column(Integer, ForeignKey('array_metric_types.id'))
+    array_metric_type_id = Column(Integer, ForeignKey('array_metric_types.id'))
     region_id = Column(Integer, ForeignKey('regions.id'))
     value = Column(ARRAY(Float))
     bias_correction = Column(ARRAY(Float))

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -299,6 +299,7 @@ class SatMeta(Base):
     )
  
     id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(256))
     sat_id = Column(Integer)
     sat_name = Column(String(128))
     sensor = Column(String(64))

--- a/src/score_table_models.py
+++ b/src/score_table_models.py
@@ -304,6 +304,8 @@ class SatMeta(Base):
     sensor = Column(String(64))
     channel = Column(String(64))
     scan_angle = Column(String(64))
+    created_at = Column(DateTime, nullable=False)
+    updated_at = Column(DateTime) 
 
     array_metric_type = relationship('ArrayMetricType', back_populates='sat_meta')
 

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -11,7 +11,7 @@ from array_metric_types import ArrayMetricTypeRequest
 
 def test_put_array_metric_type_with_sat():
     request_dict = {
-        'name': 'expt_array_metrics',
+        'name': 'array_metric_types',
         'method': 'PUT',
         'body': {
             'name': 'vertical_example_metric',
@@ -40,7 +40,7 @@ def test_put_array_metric_type_with_sat():
 
 def test_get_array_metric_type_with_sat():
     request_dict = {
-        'name':'expt_array_metrics',
+        'name':'array_metric_types',
         'method':'GET',
         'params':{
             'filters':{
@@ -66,7 +66,7 @@ def test_get_array_metric_type_with_sat():
 
 def test_put_array_metric_type_no_sat():
     request_dict = {
-        'name': 'expt_array_metrics',
+        'name': 'array_metric_types',
         'method': 'PUT',
         'body': {
             'name': 'vertical_example_metric2',
@@ -90,7 +90,7 @@ def test_put_array_metric_type_no_sat():
 
 def test_get_array_metric_type_no_sat():
     request_dict = {
-        'name':'expt_array_metrics',
+        'name':'array_metric_types',
         'method':'GET',
         'params':{
             'filters':{

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -47,7 +47,7 @@ def test_get_array_metric_type_with_sat():
                 'name':{
                     'exact':'vertical_example_metric'
                 },
-                'sat_id':123456789,
+                # 'sat_id':123456789,
                 'stat_type':{
                     'exact':'example_stat'
                 }

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2024 NOAA
+All rights reserved.
+
+Unit tests for array_metric_types.py
+
+"""
+import json 
+from array_metric_types import ArrayMetricTypeRequest
+
+def test_put_array_metric_type_with_sat():
+    request_dict = {
+        'name': 'expt_array_metrics',
+        'method': 'PUT',
+        'body': {
+            'name': 'vertical_example_metric',
+            'longname': 'vertical long name example',
+            'obs_platform': 'satellite',
+            'measurement_type': 'example_measurement_type',
+            'measurement_units': 'example_measurement_units',
+            'stat_type': 'example_stat',
+            'array_coord_labels': ['temperature', 'elevation'],
+            'array_coord_units': ['K', 'feet'],
+            'array_index_values': [[10, 20, 30][1000, 5000, 10000]],
+            'array_dimensions': [3, 3],
+            'description': json.dump({"example array metric type for testing purposes"}),
+            'sat_meta_name': 'example_sat_meta',
+            'sat_id': '123456789',
+            'sat_name': 'Example Sat Name',
+            'sat_sensor':'examplesensor',
+            'sat_channel':'1'
+        }
+    }
+
+    amtr = ArrayMetricTypeRequest(request_dict)
+    result = amtr.submit()
+    print(f'Array Metric Type PUT result: {result}')
+    assert(result.success)
+
+
+#TODO: write the get test for sat 
+#TODO: write put and get test for non sat obs platform

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -38,6 +38,28 @@ def test_put_array_metric_type_with_sat():
     print(f'Array Metric Type PUT result: {result}')
     assert(result.success)
 
+def test_get_array_metric_type_with_sat():
+    request_dict = {
+        'name':'expt_array_metrics',
+        'method':'GET',
+        'params':{
+            'filters':{
+                'name':{
+                    'exact':'vertical_example_metric'
+                },
+                'sat_id':123456789,
+                'stat_type':{
+                    'exact':'example_stat'
+                }
+            },
+            'limit':1
+        }
+    }
 
-#TODO: write the get test for sat 
+    amtr = ArrayMetricTypeRequest(request_dict)
+    result = amtr.submit()
+    print(f'Array Metric Type GET result: {result}')
+    assert(result.success)
+    assert(result.details.get('record_count') > 0)
+
 #TODO: write put and get test for non sat obs platform

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -47,7 +47,9 @@ def test_get_array_metric_type_with_sat():
                 'name':{
                     'exact':'vertical_example_metric'
                 },
-                # 'sat_id':123456789,
+                'sat_meta_name':{
+                    'exact': 'example_sat_meta'
+                },
                 'stat_type':{
                     'exact':'example_stat'
                 }
@@ -62,4 +64,49 @@ def test_get_array_metric_type_with_sat():
     assert(result.success)
     assert(result.details.get('record_count') > 0)
 
-#TODO: write put and get test for non sat obs platform
+def test_put_array_metric_type_no_sat():
+    request_dict = {
+        'name': 'expt_array_metrics',
+        'method': 'PUT',
+        'body': {
+            'name': 'vertical_example_metric2',
+            'longname': 'vertical long name example #2',
+            'obs_platform': 'insitu',
+            'measurement_type': 'example_measurement_type2',
+            'measurement_units': 'example_measurement_units2',
+            'stat_type': 'example_stat2',
+            'array_coord_labels': ['temperature', 'depth'],
+            'array_coord_units': ['K', 'm'],
+            'array_index_values': [[10, 20, 30],[1000, 5000, 10000]],
+            'array_dimensions': [3, 3],
+            'description': json.dumps("example array metric type for testing purposes with no sat")
+        }
+    }
+
+    amtr = ArrayMetricTypeRequest(request_dict)
+    result = amtr.submit()
+    print(f'Array Metric Type PUT result: {result}')
+    assert(result.success)
+
+def test_get_array_metric_type_no_sat():
+    request_dict = {
+        'name':'expt_array_metrics',
+        'method':'GET',
+        'params':{
+            'filters':{
+                'name':{
+                    'exact':'vertical_example_metric2'
+                },
+                'stat_type':{
+                    'exact':'example_stat2'
+                }
+            },
+            'limit':1
+        }
+    }
+
+    amtr = ArrayMetricTypeRequest(request_dict)
+    result = amtr.submit()
+    print(f'Array Metric Type GET result: {result}')
+    assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_array_metric_types_handler.py
+++ b/tests/test_array_metric_types_handler.py
@@ -5,7 +5,8 @@ All rights reserved.
 Unit tests for array_metric_types.py
 
 """
-import json 
+import json
+import numpy as np 
 from array_metric_types import ArrayMetricTypeRequest
 
 def test_put_array_metric_type_with_sat():
@@ -21,11 +22,11 @@ def test_put_array_metric_type_with_sat():
             'stat_type': 'example_stat',
             'array_coord_labels': ['temperature', 'elevation'],
             'array_coord_units': ['K', 'feet'],
-            'array_index_values': [[10, 20, 30][1000, 5000, 10000]],
+            'array_index_values': [[10, 20, 30],[1000, 5000, 10000]],
             'array_dimensions': [3, 3],
-            'description': json.dump({"example array metric type for testing purposes"}),
+            'description': json.dumps("example array metric type for testing purposes"),
             'sat_meta_name': 'example_sat_meta',
-            'sat_id': '123456789',
+            'sat_id': 123456789,
             'sat_name': 'Example Sat Name',
             'sat_sensor':'examplesensor',
             'sat_channel':'1'

--- a/tests/test_experiment_request_handler.py
+++ b/tests/test_experiment_request_handler.py
@@ -63,8 +63,7 @@ def test_send_get_request():
         'params': {
             'filters': {
                 'name': {
-                    # 'like': '%_3DVAR_%',
-                    'exact': 'C96L64.UFSRNR.GSI_SOCA_3DVAR.012016'
+                    'exact': 'C96L64.UFSRNR.GSI_3DVAR.012016'
                 },
                 'cycle_start': {
                     'from': '2015-01-01 00:00:00',
@@ -81,14 +80,14 @@ def test_send_get_request():
                 #     'exact': 'gsienkf'
                 # },
                 'experiment_type': {
-                    'like': '%COUPLED%'
+                    'like': '%UFSRNR%'
                 },
                 'platform': {
                     'exact': 'pw_awv1'
                 },
                 'wallclock_start': {
-                    'from': '2022-01-01 00:00:00',
-                    'to': '2022-07-01 00:00:00'
+                    'from': '2021-01-01 00:00:00',
+                    'to': '2021-08-01 00:00:00'
                 },
                 # 'wallclock_end': {
                 #     'from': '2015-01-01 00:00:00',
@@ -107,3 +106,4 @@ def test_send_get_request():
     er = ExperimentRequest(request_dict)
     result = er.submit()
     assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_expt_array_metrics_handler.py
+++ b/tests/test_expt_array_metrics_handler.py
@@ -8,7 +8,7 @@ Unit tests for expt_array_metrics.py
 from expt_array_metrics import ExptArrayMetricInputData, ExptArrayMetricRequest
 
 def test_put_exp_array_metrics_request():
-    request_dict= {
+    request_dict = {
         'name': 'expt_array_metrics',
         'method': 'PUT',
         'body': {
@@ -30,7 +30,7 @@ def test_put_exp_array_metrics_request():
 def test_get_expt_array_metrics_request():
 
     request_dict = {
-        'name': 'expt__array_metrics',
+        'name': 'expt_array_metrics',
         'method': 'GET',
         'params': {
             'datestr_format': '%Y-%m-%d %H:%M:%S',

--- a/tests/test_expt_array_metrics_handler.py
+++ b/tests/test_expt_array_metrics_handler.py
@@ -1,38 +1,36 @@
 """
 Copyright 2022 NOAA
-All rights reserved.
+All rights reserved. 
 
-Unit tests for expt_metrics.py
-
+Unit tests for expt_array_metrics.py
 """
 
-from expt_metrics import ExptMetricInputData, ExptMetricRequest
+from expt_array_metrics import ExptArrayMetricInputData, ExptArrayMetricRequest
 
-def test_put_exp_metrics_request_dict():
-
-    request_dict = {
-        'name': 'expt_metrics',
+def test_put_exp_array_metrics_request():
+    request_dict= {
+        'name': 'expt_array_metrics',
         'method': 'PUT',
         'body': {
             'expt_name': 'C96L64.UFSRNR.GSI_3DVAR.012016',
             'expt_wallclock_start': '2021-07-22 09:22:05',
-            'metrics': [
-                ExptMetricInputData('innov_stats_temperature_rmsd', 'global', '0', 'kpa', 2.6, '2015-12-02 06:00:00', None, None),
-                ExptMetricInputData('innov_stats_uvwind_rmsd', 'tropics', '50', 'kpa', 2.8, '2015-12-02 06:00:00', 24, 256)
+            'array_metrics': [
+                ExptArrayMetricInputData('vertical_example_metric','global',[[1, 2, 3],[4, 5, 6],[7, 8, 9]], [[0, 1, 0],[1, 0, 1],[0, 0, 1]], True, '2015-12-02 06:00:00', None, None),
+                ExptArrayMetricInputData('vertical_example_metric2','global',[[111, 222, 333],[444, 555, 666],[777, 888, 999]], [[1, 1, 0],[1, 0, 1],[1, 0, 0]], True, '2015-12-02 18:00:00', 24, 12)
             ],
             'datestr_format': '%Y-%m-%d %H:%M:%S'
         }
     }
 
-    emr = ExptMetricRequest(request_dict)
-    result = emr.submit()
-    print(f'Experiment metrics PUT result: {result}')
+    eamr = ExptArrayMetricRequest(request_dict)
+    result = eamr.submit()
+    print(f'Experiment Array Metrics PUT result: {result}')
     assert(result.success)
 
-def test_send_get_request():
+def test_get_expt_array_metrics_request():
 
     request_dict = {
-        'name': 'expt_metrics',
+        'name': 'expt__array_metrics',
         'method': 'GET',
         'params': {
             'datestr_format': '%Y-%m-%d %H:%M:%S',
@@ -48,11 +46,8 @@ def test_send_get_request():
                 },
                 'metric_types': {
                     'name': {
-                        'exact': ['innov_stats_temperature_rmsd']
+                        'exact': ['vertical_example_metric']
                     },
-                    'stat_type': {
-                        'exact': ['rmsd']
-                    }
                 },
                 'regions': {
                     'name': {
@@ -66,13 +61,12 @@ def test_send_get_request():
                 },
             },
             'ordering': [
-                # {'name': 'id', 'order_by': 'asc'}
                 {'name': 'time_valid', 'order_by': 'asc'}
             ]
         }
     }
 
-    emr = ExptMetricRequest(request_dict)
-    result = emr.submit()
+    eamr = ExptArrayMetricRequest(request_dict)
+    result = eamr.submit()
     assert(result.success)
     assert(result.details.get('record_count') > 0)

--- a/tests/test_expt_file_counts_handler.py
+++ b/tests/test_expt_file_counts_handler.py
@@ -68,4 +68,5 @@ def test_get_expt_file_counts_dict():
     result = efcr.submit()
     print(f'Expt File Counts GET results: {result}')
     assert(result.success)
+    assert(result.details.get('record_count') > 0)
 

--- a/tests/test_expt_metrics_handler.py
+++ b/tests/test_expt_metrics_handler.py
@@ -96,3 +96,4 @@ def test_send_get_request():
     emr = ExptMetricRequest(request_dict)
     result = emr.submit()
     assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_file_types_handler.py
+++ b/tests/test_file_types_handler.py
@@ -48,3 +48,4 @@ def test_file_type_get_request():
     result = ftr.submit()
     print(f'File type GET results: {result}')
     assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_harvest_metrics_engine.py
+++ b/tests/test_harvest_metrics_engine.py
@@ -33,7 +33,8 @@ def test_run_atm_inc_log_harvester():
             'harvester_name': 'inc_logs',
             'filename': FILE_PATH_ATM_INC_LOGS,
             'statistic': ['mean'],
-            'variable': ['o3mr_inc']
+            'variable': ['o3mr_inc'],
+            'cycletime': '1995-01-01 00:00:00'
         }
     }
 

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -227,3 +227,4 @@ def test_send_get_request():
     er = MetricTypeRequest(request_dict)
     result = er.submit()
     assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_sat_meta_handler.py
+++ b/tests/test_sat_meta_handler.py
@@ -15,7 +15,7 @@ def test_sat_meta_input_dict():
         'method' : 'PUT',
         'body' :{
             'name': 'example_sat_meta',
-            'sat_id': '123456789',
+            'sat_id': 123456789,
             'sat_name': 'Example Sat Name',
             'sensor': 'examplesensor',
             'channel': '1',

--- a/tests/test_sat_meta_handler.py
+++ b/tests/test_sat_meta_handler.py
@@ -1,0 +1,52 @@
+"""
+Copyright 2024 NOAA
+All rights reserved.
+
+Unit tests for sat_meta.py
+
+"""
+import os
+import pathlib
+import pytest
+import json
+from collections import namedtuple
+
+from sat_meta import SatMetaRequest
+
+
+def test_sat_meta_input_dict():
+    request_dict = {
+        'name': 'sat_meta',
+        'method' : 'PUT',
+        'body' :{
+            'name': 'example_sat_meta',
+            'sat_id': '123456789',
+            'sat_name': 'Example Sat Name',
+            'sensor': 'examplesensor',
+            'channel': '1',
+            'scan_angle':'90 degreees sectors fore- and aft-'
+        }
+    }
+
+    smr = SatMetaRequest(request_dict)
+    result = smr.submit()
+    print(f'Sat Meta PUT results: {result}')
+    assert(result.success)
+
+def test_sat_meta_get_request():
+    request_dict = {
+        'name': 'sat_meta',
+        'method': 'GET',
+        'params' : {
+            'filters': {
+                'name' :{
+                    'exact' : 'example_sat_meta'
+                }
+            }
+        }
+    }
+
+    smr = SatMetaRequest(request_dict)
+    result = smr.submit()
+    print(f'Sat Meta GET results: {result}')
+    assert(result.success)

--- a/tests/test_sat_meta_handler.py
+++ b/tests/test_sat_meta_handler.py
@@ -45,3 +45,4 @@ def test_sat_meta_get_request():
     result = smr.submit()
     print(f'Sat Meta GET results: {result}')
     assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_sat_meta_handler.py
+++ b/tests/test_sat_meta_handler.py
@@ -5,11 +5,6 @@ All rights reserved.
 Unit tests for sat_meta.py
 
 """
-import os
-import pathlib
-import pytest
-import json
-from collections import namedtuple
 
 from sat_meta import SatMetaRequest
 

--- a/tests/test_storage_locations_handler.py
+++ b/tests/test_storage_locations_handler.py
@@ -45,3 +45,4 @@ def test_storage_location_get_request():
     result = slr.submit()
     print(f'Storage location GET result: {result}')
     assert(result.success)
+    assert(result.details.get('record_count') > 0)


### PR DESCRIPTION
This PR introduces the ability to store experiment records with values in the form of arrays.

 In order to do this, three new tables and their respective classes for interaction were developed: sat_meta for satellite meta data, array_metric_types for the new types of metric which contains the meta data necessary to understand the array values and links to the sat_meta table, and the expt_array_metrics table for storing the actual value of metrics which links to the array_metric_types table. 

Additional work was done to clean up the expt_metrics class and test cases in each file to match the improved structure developed as part of the new files particularly to improve error handling and identify failing tests more proactively. The README has been updated with the new table information.

All new files have been tested via the new test cases as well as verified in the database as successful.