### PR TITLE
fix file counts filtering bug

### DIFF
--- a/src/expt_file_counts.py
+++ b/src/expt_file_counts.py
@@ -146,47 +146,6 @@ def get_file_count_from_body(body):
     )
 
     return file_count
-    
-# def get_time_filter(filter_dict, cls, key, constructed_filter):
-#     if not isinstance(filter_dict, dict):
-#         msg = f'Invalid type for filters, must be \'dict\', was ' \
-#             f'type: {type(filter_dict)}'
-#         raise TypeError(msg)
-
-#     value = filter_dict.get(key)
-#     if value is None:
-#         print(f'No \'{key}\' filter detected')
-#         return constructed_filter
-
-#     exact_datetime = time_utils.get_time(value.get(db_utils.EXACT_DATETIME))
-
-#     if exact_datetime is not None:
-#         constructed_filter[key] = (
-#             getattr(cls, key) == exact_datetime
-#         )
-#         return constructed_filter
-
-#     from_datetime = time_utils.get_time(value.get(db_utils.FROM_DATETIME))
-#     to_datetime = time_utils.get_time(value.get(db_utils.TO_DATETIME))
-
-#     if from_datetime is not None and to_datetime is not None:
-#         if to_datetime < from_datetime:
-#             raise ValueError('\'from\' must be older than \'to\'')
-        
-#         constructed_filter[key] = and_(
-#             getattr(cls, key) >= from_datetime,
-#             getattr(cls, key) <= to_datetime
-#         )
-#     elif from_datetime is not None:
-#         constructed_filter[key] = (
-#             getattr(cls, key) >= from_datetime
-#         )
-#     elif to_datetime is not None:
-#         constructed_filter[key] = (
-#             getattr(cls, key) <= to_datetime
-#         )
-
-#     return constructed_filter
 
 def get_time_filter(filter_dict, cls, key, constructed_filter):
     if not isinstance(filter_dict, dict):
@@ -246,49 +205,6 @@ def validate_list_of_strings(values):
             raise TypeError(msg)
     
     return values
-
-# def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
-#     if not isinstance(filter_dict, dict):
-#         msg = f'Invalid type for filters, must be \'dict\', was ' \
-#             f'type: {type(filter_dict)}'
-#         raise TypeError(msg)
-
-#     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-#     string_flt = filter_dict.get(key)
-#     print(f'string_flt: {string_flt}')
-
-#     if string_flt is None:
-#         print(f'No \'{key}\' filter detected')
-#         return constructed_filter
-
-#     like_filter = string_flt.get('like')
-#     # prefer like search over exact match if both exist
-#     if like_filter is not None:
-#         constructed_filter[key_name] = (getattr(cls, key).like(like_filter))
-#         return constructed_filter
-
-#     exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
-#     if exact_match_filter is not None:
-#         constructed_filter[key_name] = (getattr(cls, key).in_(exact_match_filter))
-
-#     return constructed_filter
-
-# def get_float_filter(filter_dict, cls, key, constructed_filter):
-#     if not isinstance(filter_dict, dict):
-#         msg = f'Invalid type for filters, must be \'dict\', was ' \
-#             f'type: {type(filter_dict)}'
-#         raise TypeError(msg)
-
-#     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-#     float_flt = filter_dict.get(key)
-
-#     if float_flt is None:
-#         print(f'No \'{key}\' filter detected')
-#         return constructed_filter
-
-#     constructed_filter[key] = ( getattr(cls, key) == float_flt )
-    
-#     return constructed_filter
 
 def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
     if not isinstance(filter_dict, dict):

--- a/src/expt_file_counts.py
+++ b/src/expt_file_counts.py
@@ -250,10 +250,15 @@ def get_float_filter(filter_dict, cls, key, constructed_filter):
     return constructed_filter
 
 def get_experiments_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        print('No experiment filters provided')
+        return constructed_filter
+    
     if not isinstance(filter_dict, dict):
-        msg = f'Invalid type for filter, must be \'dict\', was ' \
-            f'type: {type(filter_dict)}'
-        raise TypeError(msg)
+        msg = f'Invalid type for experiment filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}. No experiment filters will be added.'
+        print(msg)
+        return constructed_filter
     
     if not isinstance(constructed_filter, dict):
         msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
@@ -275,6 +280,21 @@ def get_experiments_filter(filter_dict, constructed_filter):
     return constructed_filter
 
 def get_file_types_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        print('No file type filters provided')
+        return constructed_filter
+    
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for file type filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}. No file type filters will be added.'
+        print(msg)
+        return constructed_filter
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)   
+    
     constructed_filter = get_string_filter(
         filter_dict, ft, 'name', constructed_filter, 'file_type_name')
 
@@ -287,6 +307,21 @@ def get_file_types_filter(filter_dict, constructed_filter):
     return constructed_filter
 
 def get_storage_locations_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        print('No storage location filters provided')
+        return constructed_filter
+    
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for storage location filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}. No storage location filters will be added.'
+        print(msg)
+        return constructed_filter
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)   
+    
     constructed_filter = get_string_filter(
         filter_dict, sl, 'name', constructed_filter, 'storage_location_name')
 

--- a/src/plot_file_counts.py
+++ b/src/plot_file_counts.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-"""
-Copyright 2023 NOAA
+"""Copyright 2023 NOAA
 All rights reserved.
 
 Collection of methods to facilitate handling of score db requests
@@ -18,7 +17,6 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame
 from matplotlib import pyplot as plt
-
 
 from expt_file_counts import ExptFileCountRequest
 from file_counts_plot_attrs import plot_attrs
@@ -137,13 +135,19 @@ def get_experiment_file_counts(request_data):
     time_valid_to = datetime.strftime(request_data.time_valid.end, 
                                       request_data.datetime_str)
     
-    request_dict = {'name' : 'expt_file_counts', 'method': 'GET',
-                    'params' : {'filters':
-                                   {'experiment': {'experiment_name': {
-                                           'exact': request_data.experiment['name']['exact']}},
-                                    'file_types': {'file_type_name': {'exact': 'example_type'}},
-                                    'storage_locations': {'storage_loc_name':
-                                                            {'exact': 's3_example_bucket'}}}}}
+    request_dict = {'name': 'expt_file_counts',
+                    'method': 'GET',
+                    'params': {
+                        'filters': {
+                            'experiment': {
+                                'experiment_name': {
+                                    'exact':
+                                        request_data.experiment['name']['exact']
+                                }
+                            }
+                        }
+                    }
+    }
     print(f'request_dict: {request_dict}')
 
     efcr = ExptFileCountRequest(request_dict)

--- a/tests/test_expt_file_counts_handler.py
+++ b/tests/test_expt_file_counts_handler.py
@@ -60,6 +60,7 @@ def test_get_expt_file_counts_dict():
                         'exact': 's3_example_bucket',
                     },
                 },
+                'forecast_hour': 120
             }
         }
     }

--- a/tests/test_expt_file_counts_handler.py
+++ b/tests/test_expt_file_counts_handler.py
@@ -71,3 +71,24 @@ def test_get_expt_file_counts_dict():
     assert(result.success)
     assert(result.details.get('record_count') > 0)
 
+def test_get_expt_file_counts_dict_only_count_filter():
+    request_dict = {
+        'name' : 'expt_file_counts',
+        'method': 'GET',
+        'params' : {
+            'filters': {
+                'count': 1230,
+                'folder_path': {
+                    'exact': 'noaa-example-score-db-bucket/reanalysis/2023/02/23/2023022306'
+                }
+            },
+            
+        }
+    }
+
+    efcr = ExptFileCountRequest(request_dict)
+    result = efcr.submit()
+    print(f'Expt File Counts GET results: {result}')
+    assert(result.success)
+    assert(result.details.get('record_count') > 0)
+


### PR DESCRIPTION
This PR fixes the problems that were occurring with file counts in regards to filtering. Now, file count get calls can be filtered based on files in the file counts table as well as the relevant experiments, file_types, and storage_location values. While updating this, I also now return the basic values from these tables in the results consistent with how other joined table values are returned such as experiment metrics. Finally, this adds an additional filter test field that is in the file_counts table to hit all parts of the filtering code. 

Additionally, this removes a dependency which required that filter dictionaries be included for the related tables of experiments, storage_locations, and file_types. Now those are optional inputs for the filters dict. An additional test was added to check this functionality. 

Changed files:
- expt_file_counts.py- fix filtering and returning values
- test_expt_file_counts_handler.py - improve test case to hit all paths of code 

All existing tests have been run and passed (except the expected harvest innov stats failure). 