### PR TITLE
remove superfluous engine calls

### DIFF
--- a/src/score_db/experiments.py
+++ b/src/score_db/experiments.py
@@ -369,7 +369,6 @@ class ExperimentRequest:
 
     
     def put_experiment(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
 
         record = exp(
@@ -463,7 +462,6 @@ class ExperimentRequest:
 
     
     def get_experiments(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
 
         q = session.query(

--- a/src/score_db/experiments.py
+++ b/src/score_db/experiments.py
@@ -439,6 +439,7 @@ class ExperimentRequest:
             message = f'Attempt to {action} experiment record FAILED'
             error_msg = f'Failed to insert/update record - err: {err}'
             print(f'error_msg: {error_msg}')
+            session.close()
         else:
             message = f'Attempt to {action} experiment record SUCCEEDED'
             error_msg = None
@@ -507,11 +508,13 @@ class ExperimentRequest:
         except Exception as err:
             message = 'Request for experiment records FAILED'
             error_msg = f'Failed to get experiment records - err: {err}'
+            session.close()
         else:
             message = 'Request for experiment records SUCCEEDED'
             for idx, row in results.iterrows():
                 print(f'idx: {idx}, row: {row}')
             record_count = len(results.index)
+            session.close()
         
         details = {}
         # details['filters'] = self.filters

--- a/src/score_db/expt_array_metrics.py
+++ b/src/score_db/expt_array_metrics.py
@@ -672,6 +672,7 @@ class ExptArrayMetricRequest:
             session.close()
 
         else:
+            session.close()
             return self.failed_request('No expt array metric records were discovered to be inserted')
 
         return DbActionResponse(
@@ -770,6 +771,7 @@ class ExptArrayMetricRequest:
                 columns=ExptArrayMetricsData._fields
             )
         except Exception as err:
+            session.close()
             trcbk = traceback.format_exc()
             msg = f'Problem casting array exeriment metrics query output into pandas ' \
                 f'DataFrame - err: {trcbk}'

--- a/src/score_db/expt_file_counts.py
+++ b/src/score_db/expt_file_counts.py
@@ -634,6 +634,7 @@ class ExptFileCountRequest:
             message = f'Attempt to insert experiment stored file counts record FAILED'
             error_msg = f'Failed to insert record - err: {err}'
             print(f'error_msg: {error_msg}')
+            session.close()
         else:
             message = f'Attempt to insert experiment stored file counts record SUCCEEDED'
             error_msg = None
@@ -736,5 +737,6 @@ class ExptFileCountRequest:
         )
 
         print(f'response: {response}')
-
+        
+        session.close()
         return response

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -597,7 +597,6 @@ class ExptMetricRequest:
 
     
     def get_experiment_metrics(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
 
         # set basic query

--- a/src/score_db/metric_types.py
+++ b/src/score_db/metric_types.py
@@ -219,7 +219,6 @@ class MetricTypeRequest:
 
     
     def put_metric_type(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
 
         insert_stmt = insert(mt).values(
@@ -290,7 +289,6 @@ class MetricTypeRequest:
 
     
     def get_metric_types(self):
-        engine = stm.get_engine_from_settings()
         session = stm.get_session()
 
         q = session.query(

--- a/src/score_db/score_table_models.py
+++ b/src/score_db/score_table_models.py
@@ -48,7 +48,7 @@ def get_engine(user, passwd, host, port, db):
 
     db_engine = create_engine(
         url,
-        pool_size=10,
+        pool_size=15,
         echo=False,
         connect_args={"options": "-c timezone=utc"}
     )

--- a/src/score_db/score_table_models.py
+++ b/src/score_db/score_table_models.py
@@ -48,7 +48,7 @@ def get_engine(user, passwd, host, port, db):
 
     db_engine = create_engine(
         url,
-        pool_size=3,
+        pool_size=10,
         echo=False,
         connect_args={"options": "-c timezone=utc"}
     )

--- a/src/score_db/score_table_models.py
+++ b/src/score_db/score_table_models.py
@@ -332,7 +332,4 @@ class InstrumentMeta(Base):
 Base.metadata.create_all(engine)
 
 def get_session():
-    engine = get_engine_from_settings()
-    Session = sessionmaker(bind=engine)
-
     return Session()

--- a/src/score_db/score_table_models.py
+++ b/src/score_db/score_table_models.py
@@ -48,7 +48,7 @@ def get_engine(user, passwd, host, port, db):
 
     db_engine = create_engine(
         url,
-        pool_size=50,
+        pool_size=3,
         echo=False,
         connect_args={"options": "-c timezone=utc"}
     )


### PR DESCRIPTION
This PR removes the code that was creating multiple engines and instead uses the same engine (the one already created within the score table models file) for generating multiple sessions which is the correct desired behavior. This should address problems occurring due to connection limits being hit since the pool size of the engine was not able to be used in the old configuration. 


All tests are passing. This does not change any codebase behavior, other files were just removing already unused calls to prevent any future calls to the engine instead of session. 