### PR TITLE
hot fix for putting experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .DS_Store
 .vscode/
+*.egg-info

--- a/src/score_db/experiments.py
+++ b/src/score_db/experiments.py
@@ -425,6 +425,7 @@ class ExperimentRequest:
         try:
             result = session.execute(do_update_stmt)
             session.flush()
+            session.commit()
             result_row = result.fetchone()
             action = db_utils.INSERT
             if result_row.updated_at is not None:


### PR DESCRIPTION
put_experiment function was missing the session.commit() to save data before the session close. this was causing a success message but the data wasn't saved to the database. 

all other put functions have been reviewed to contain the commit call, no other error of this type should occur again. 

also updating .gitinfo with another needed extension