### PR TITLE
Add instrument and sat meta to existing metric tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,8 @@ regions
 metric_types
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    obs_platform = Column(String(128), nullable=True)
+    instrument_meta_id = Column(Integer, ForeignKey('instrument_meta.id'), nullable=True)
     name = Column(String(128), nullable=False)
     long_name = Column(String(128))
     measurement_type = Column(String(64), nullable=False)
@@ -422,6 +424,7 @@ metric_types
     updated_at = Column(DateTime)
     
     metrics = relationship('ExperimentMetric', back_populates='metric_type')
+    instrument_meta = relationship('InstrumentMeta', back_populates='metric_type')
 ```
 
 ```sh
@@ -431,6 +434,7 @@ expt_metrics
     experiment_id = Column(Integer, ForeignKey('experiments.id'))
     metric_type_id = Column(Integer, ForeignKey('metric_types.id'))
     region_id = Column(Integer, ForeignKey('regions.id'))
+    sat_meta_id = Column(Integer, ForeignKey('sat_meta.id'), nullable=True)
     elevation = Column(Float, nullable=False)
     elevation_unit = Column(String(32))
     value = Column(Float)
@@ -442,6 +446,7 @@ expt_metrics
     experiment = relationship('Experiment', back_populates='metrics')
     metric_type = relationship('MetricType', back_populates='metrics')
     region = relationship('Region', back_populates='metrics')
+    sat_meta = relationship('SatMeta', back_populates='metrics')
 ```
 ```sh
 storage_locations
@@ -548,6 +553,7 @@ sat_meta
     updated_at = Column(DateTime)
 
     array_metrics = relationship('ExptArrayMetric', back_populates='sat_meta')
+    metrics = relationship('ExperimentMetric', back_populates='sat_meta')
 ```
 
 ```sh
@@ -561,6 +567,7 @@ instrument_meta
     updated_at = Column(DateTime) 
 
     array_metric_type = relationship('ArrayMetricType', back_populates='instrument_meta')
+    metric_type = relationship('MetricType', back_populates='instrument_meta')
 ```
 
 ## Request Dictionaries / YAML Formats
@@ -698,15 +705,19 @@ request_dict = {
                 'value': value,
                 'time_valid': time_valid,
                 'forecast_hour' : forecast_hour,
-                'ensemble_member' : ensemble_member
+                'ensemble_member' : ensemble_member,
+                'sat_meta_name': sat_meta_name,
+                'sat_id': sat_id,
+                'sat_name': sat_name,
+                'sat_short_name': sat_short_name
             },
             'datestr_format': '%Y-%m-%d %H:%M:%S',
         }
     }
 ```
-Values which can be null or not provided: elevation_unit, forecast_hour, ensemble_member
+Values which can be null or not provided: elevation_unit, forecast_hour, ensemble_member, sat_meta_name, sat_id, sat_name, sat_short_name
 
-Note: for a successful PUT call, the experiment, region, and metric type referenced in the body must already be registered using the score_db_base.py. See the first example above on How To Register an Experiment. The process is the same for the other data types. 
+Note: for a successful PUT call, the experiment, region, metric type, and sat meta referenced in the body must already be registered using the score_db_base.py. See the first example above on How To Register an Experiment. The process is the same for the other data types. 
 
 ### Harvest Metrics Dictionary 
 Harvest metrics only accepts PUT calls, therefore a method is not required. Any GET call for metrics should be through 'expt_metrics'. 
@@ -800,12 +811,16 @@ request_types = {
             'measurement_type': measurement_type,
             'measurement_units': units,
             'stat_type': stat_type,
+            'obs_platform': obs_platform,
+            'instrument_meta_name': instrument_meta_name,
             'description': #JSON FORMAT OF DESCRIPTION
         }
     }
 ```
 
-Values which can be null or not provided: measurement_units, stat_type, description
+Values which can be null or not provided: measurement_units, stat_type, obs_platform, instrument_meta_name, description
+
+Note: for a successful PUT call, the instrument meta referenced in the body must already be registered using the score_db_base.py. See the first example above on How To Register an Experiment. The process is the same for the other data types. 
 
 ### Regions Dictionaries
 Example format of request dictionary for 'regions' calls.

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -41,6 +41,7 @@ from score_db.score_table_models import SatMeta as sm
 from score_db.score_table_models import InstrumentMeta as im
 from score_db.experiments import Experiment, ExperimentData
 from score_db.experiments import ExperimentRequest
+from score_db.sat_meta import SatMetaRequest
 import score_db.regions as rg
 import score_db.metric_types as mt
 from score_db import time_utils
@@ -373,30 +374,6 @@ def get_sat_meta_filter(filter_dict, constructed_filter):
 
     return constructed_filter
 
-def get_sat_meta_filter(filter_dict, constructed_filter):
-    if filter_dict is None:
-        return constructed_filter
-
-    if not isinstance(filter_dict, dict):
-        msg = f'Invalid type for filter, must be \'dict\', was ' \
-            f'type: {type(filter_dict)}'
-        raise TypeError(msg)
-    
-    if not isinstance(constructed_filter, dict):
-        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
-            f'was type: {type(filter_dict)}'
-        raise TypeError(msg)
-
-    constructed_filter = get_string_filter(filter_dict, sm, 'name', constructed_filter, 'name')
-
-    constructed_filter = get_int_filter(filter_dict, sm, 'sat_id', constructed_filter)
-
-    constructed_filter = get_string_filter(filter_dict, sm, 'sat_name', constructed_filter, 'sat_name')
-
-    constructed_filter = get_string_filter(filter_dict, sm, 'short_name', constructed_filter, 'short_name')
-
-    return constructed_filter
-
 def get_expt_record(body):
 
     # get experiment name
@@ -452,6 +429,75 @@ def get_expt_record(body):
     
     return records
 
+def get_sat_meta_id_from_metric(metric):
+    sat_meta_id = -1
+    try:    
+        sat_meta_name = metric.sat_meta_name
+        sat_id = metric.sat_id
+        sat_name = metric.sat_name
+        sat_short_name = metric.sat_short_name
+    except Exception as err:
+        print(f'Required sat meta input value not found: {err}')
+        return sat_meta_id
+    
+    if sat_meta_name is None and sat_id is None and sat_name is None and sat_short_name is None:
+        return sat_meta_id
+    
+    sat_meta_request = {
+        'name': 'sat_meta',
+        'method': db_utils.HTTP_GET,
+        'params': {
+            'filters': {
+                'name': {
+                    'exact': sat_meta_name
+                },
+                'sat_name': {
+                    'exact': sat_name
+                },
+                'short_name': {
+                    'exact': sat_short_name
+                },
+                'sat_id': sat_id
+            },
+            'record_limit': 1
+        }
+    }
+
+    print(f'sat_meta_request: {sat_meta_request}')
+
+    smr = SatMetaRequest(sat_meta_request)
+
+    results = smr.submit()
+    print(f'results: {results}')
+
+    record_cnt = 0
+    try:
+        if results.success is True:
+            records = results.details.get('records')
+            if records is None:
+                msg = 'Request for sat meta record did not return a record'
+                raise ExptMetricsError(msg)
+            record_cnt = records.shape[0]
+        else:
+            msg = f'Problems encountered requesting sat meta data.'
+            # create error return db_action_response
+            raise ExptMetricsError(msg)
+        if record_cnt <= 0:
+            msg = 'Request for sat meta record did not return a record'
+            raise ExptMetricsError(msg)
+        
+    except Exception as err:
+        msg = f'Problems encountered requesting sat meta data. err - {err}'
+        raise ExptMetricsError(msg) from err
+        
+    try:
+        sat_meta_id = records[sm.id.name].iat[0]
+    except Exception as err:
+        error_msg = f'Problem finding sat meta id from record: {records} ' \
+            f'- err: {err}'
+        print(f'error_msg: {error_msg}')
+        raise ExptMetricsError(error_msg) from err
+    return sat_meta_id
 
 @dataclass
 class ExptMetricRequest:
@@ -537,6 +583,8 @@ class ExptMetricRequest:
         
         constructed_filter = get_regions_filter(
             self.filters.get('regions'), constructed_filter)
+        
+        constructed_filter = get_sat_meta_filter(self.filters.get('sat_meta'), constructed_filter)
 
         constructed_filter = get_time_filter(
             self.filters, ex_mt, 'time_valid', constructed_filter)
@@ -618,6 +666,8 @@ class ExptMetricRequest:
         for row in metrics:
             
             value = row.value
+            sat_meta_id = get_sat_meta_id_from_metric(row)
+            sat_meta_input_id = sat_meta_id if sat_meta_id > 0 else None
 
             if math.isnan(value):
                 value = None
@@ -626,6 +676,7 @@ class ExptMetricRequest:
                 experiment_id=self.expt_id,
                 metric_type_id=mt_df_dict[row.name],
                 region_id=rg_df_dict[row.region_name],
+                sat_meta_id=sat_meta_input_id,
                 elevation=row.elevation,
                 elevation_unit=row.elevation_unit,
                 value=value,
@@ -656,24 +707,22 @@ class ExptMetricRequest:
 
         # we need to determine the primary key id from the experiment
         # all calls to this function must return a DbActionResponse object
-        expt_record = get_expt_record(self.body)
-        expt_id = self.get_first_expt_id_from_df(expt_record)
         records = self.get_expt_metrics_from_body(self.body)
 
 
         if len(records) > 0:
-            for record in records:
-                msg = f'record.experiment_id: {record.experiment_id}, '
-                msg += f'record.metric_type_id: {record.metric_type_id}, '
-                msg += f'record.region_id: {record.region_id}, '
-                msg += f'record.elevation: {record.elevation}, '
-                msg += f'record.elevation_unit: {record.elevation_unit}, '
-                msg += f'record.value: {record.value}, '
-                msg += f'record.time_valid: {record.time_valid}, '
-                msg += f'record.forecast_hour: {record.forecast_hour},'
-                msg += f'record.ensemble_member: {record.ensemble_member},'
-                msg += f'record.created_at: {record.created_at}'
-                print(f'record: {msg}')
+            # for record in records:
+                # msg = f'record.experiment_id: {record.experiment_id}, '
+                # msg += f'record.metric_type_id: {record.metric_type_id}, '
+                # msg += f'record.region_id: {record.region_id}, '
+                # msg += f'record.elevation: {record.elevation}, '
+                # msg += f'record.elevation_unit: {record.elevation_unit}, '
+                # msg += f'record.value: {record.value}, '
+                # msg += f'record.time_valid: {record.time_valid}, '
+                # msg += f'record.forecast_hour: {record.forecast_hour},'
+                # msg += f'record.ensemble_member: {record.ensemble_member},'
+                # msg += f'record.created_at: {record.created_at}'
+                # print(f'record: {msg}')
 
             session.bulk_save_objects(records)
             session.commit()
@@ -699,6 +748,10 @@ class ExptMetricRequest:
             mts, ex_mt.metric_type
         ).join(
             rgs, ex_mt.region
+        ).outerjoin(
+            sm, ex_mt.sat_meta
+        ).outerjoin(
+            im, ex_mt.instrument_meta
         )
 
         # add filters
@@ -715,6 +768,24 @@ class ExptMetricRequest:
         print(f'len(metrics): {len(metrics)}')
         parsed_metrics = []
         for metric in metrics:
+            #handle potential nulls from outer joins
+            sat_meta_id=None
+            sat_meta_name=None
+            sat_id=None
+            sat_name=None
+            sat_short_name=None
+            metric_instrument_name=None
+            metric_instrument_num_channels=None
+            if metric.sat_meta is not None:
+                sat_meta_id=metric.sat_meta.id
+                sat_meta_name=metric.sat_meta.name
+                sat_id=metric.sat_meta.sat_id
+                sat_name=metric.sat_meta.sat_name
+                sat_short_name=metric.sat_meta.short_name
+            if metric.array_metric_type.instrument_meta is not None:
+                metric_instrument_name=metric.array_metric_type.instrument_meta.name
+                metric_instrument_num_channels=metric.array_metric_type.instrument_meta.num_channels
+
             record = ExptMetricsData(
                 id=metric.id,
                 name=metric.metric_type.name,
@@ -732,8 +803,17 @@ class ExptMetricRequest:
                 metric_type=metric.metric_type.measurement_type,
                 metric_unit=metric.metric_type.measurement_units,
                 metric_stat_type=metric.metric_type.stat_type,
+                metric_instrument_meta_id=metric.metric_type.instrument_meta_id,
+                metric_instrument_name=metric_instrument_name,
+                metric_instrument_num_channels=metric_instrument_num_channels,
+                metric_obs_platform=metric.metric_type.obs_platform,
                 region_id=metric.region.id,
                 region=metric.region.name,
+                sat_meta_id=sat_meta_id,
+                sat_meta_name=sat_meta_name,
+                sat_id=sat_id,
+                sat_name=sat_name,
+                sat_short_name=sat_short_name,
                 created_at=metric.created_at
             )
             parsed_metrics.append(record)

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -37,6 +37,7 @@ from score_db.score_table_models import Experiment as exp
 from score_db.score_table_models import ExperimentMetric as ex_mt
 from score_db.score_table_models import MetricType as mts
 from score_db.score_table_models import Region as rgs
+from score_db.score_table_models import SatMeta as sm
 from score_db.experiments import Experiment, ExperimentData
 from score_db.experiments import ExperimentRequest
 import score_db.regions as rg
@@ -57,7 +58,11 @@ ExptMetricInputData = namedtuple(
         'value',
         'time_valid',
         'forecast_hour',
-        'ensemble_member'
+        'ensemble_member',
+        'sat_meta_name',
+        'sat_id',
+        'sat_name',
+        'sat_short_name',
     ],
 )
 
@@ -81,8 +86,17 @@ ExptMetricsData = namedtuple(
         'metric_type',
         'metric_unit',
         'metric_stat_type',
+        'metric_obs_platform',
+        'metric_instrument_meta_id',
+        'metric_instrument_name',
+        'metric_instrument_num_channels',
         'region_id',
         'region',
+        'sat_meta_id',
+        'sat_meta_name',
+        'sat_id',
+        'sat_name',
+        'sat_short_name',
         'created_at'
     ],
 )
@@ -276,6 +290,8 @@ def get_metric_types_filter(filter_dict, constructed_filter):
         'metric_type_stat_type'
     )
 
+    constructed_filter = get_string_filter(filter_dict, im, 'name', constructed_filter, 'instrument_meta_name')
+
     return constructed_filter
 
 
@@ -303,6 +319,30 @@ def get_regions_filter(filter_dict, constructed_filter):
     constructed_filter = get_float_filter(filter_dict, rgs, 'east_lon', constructed_filter)
 
     constructed_filter = get_float_filter(filter_dict, rgs, 'west_lon', constructed_filter)
+
+    return constructed_filter
+
+def get_sat_meta_filter(filter_dict, constructed_filter):
+    if filter_dict is None:
+        return constructed_filter
+
+    if not isinstance(filter_dict, dict):
+        msg = f'Invalid type for filter, must be \'dict\', was ' \
+            f'type: {type(filter_dict)}'
+        raise TypeError(msg)
+    
+    if not isinstance(constructed_filter, dict):
+        msg = 'Invalid type for constructed_filter, must be \'dict\', ' \
+            f'was type: {type(filter_dict)}'
+        raise TypeError(msg)
+
+    constructed_filter = get_string_filter(filter_dict, sm, 'name', constructed_filter, 'name')
+
+    constructed_filter = get_int_filter(filter_dict, sm, 'sat_id', constructed_filter)
+
+    constructed_filter = get_string_filter(filter_dict, sm, 'sat_name', constructed_filter, 'sat_name')
+
+    constructed_filter = get_string_filter(filter_dict, sm, 'short_name', constructed_filter, 'short_name')
 
     return constructed_filter
 

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -707,6 +707,8 @@ class ExptMetricRequest:
 
         # we need to determine the primary key id from the experiment
         # all calls to this function must return a DbActionResponse object
+        expt_record = get_expt_record(self.body)
+        expt_id = self.get_first_expt_id_from_df(expt_record)
         records = self.get_expt_metrics_from_body(self.body)
 
 

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -747,13 +747,13 @@ class ExptMetricRequest:
         ).join(
             exp, ex_mt.experiment
         ).join(
-            mts, ex_mt.metric_type
-        ).join(
             rgs, ex_mt.region
         ).outerjoin(
             sm, ex_mt.sat_meta
+        ).join(
+            mts, ex_mt.metric_type
         ).outerjoin(
-            im, ex_mt.instrument_meta
+            im, mts.instrument_meta
         )
 
         # add filters
@@ -784,9 +784,9 @@ class ExptMetricRequest:
                 sat_id=metric.sat_meta.sat_id
                 sat_name=metric.sat_meta.sat_name
                 sat_short_name=metric.sat_meta.short_name
-            if metric.array_metric_type.instrument_meta is not None:
-                metric_instrument_name=metric.array_metric_type.instrument_meta.name
-                metric_instrument_num_channels=metric.array_metric_type.instrument_meta.num_channels
+            if metric.metric_type.instrument_meta is not None:
+                metric_instrument_name=metric.metric_type.instrument_meta.name
+                metric_instrument_num_channels=metric.metric_type.instrument_meta.num_channels
 
             record = ExptMetricsData(
                 id=metric.id,

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -179,7 +179,7 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
         raise TypeError(msg)
 
     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-    string_flt = filter_dict.get(key)
+    string_flt = filter_dict.get(key_name)
     print(f'string_flt: {string_flt}')
 
     if string_flt is None:
@@ -189,12 +189,12 @@ def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
     like_filter = string_flt.get('like')
     # prefer like search over exact match if both exist
     if like_filter is not None:
-        constructed_filter[key_name] = (getattr(cls, key).like(like_filter))
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).like(like_filter))
         return constructed_filter
 
     exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
     if exact_match_filter is not None:
-        constructed_filter[key_name] = (getattr(cls, key).in_(exact_match_filter))
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).in_(exact_match_filter))
 
     return constructed_filter
 

--- a/src/score_db/harvest_metrics.py
+++ b/src/score_db/harvest_metrics.py
@@ -91,7 +91,11 @@ class HarvestMetricsRequest(object):
                 data.value,
                 data.cycletime,
                 data.forecast_hour,
-                data.ensemble_member
+                data.ensemble_member,
+                data.sat_meta_name, 
+                data.sat_id,
+                data.sat_name,
+                data.sat_short_name
             )
 
             expt_metrics.append(item)

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -22,7 +22,11 @@ MetricTableData = namedtuple(
         'value',
         'cycletime',
         'forecast_hour',
-        'ensemble_member'
+        'ensemble_member',
+        'sat_meta_name',
+        'sat_id',
+        'sat_name',
+        'sat_short_name',
     ],
 )
 
@@ -66,6 +70,10 @@ def inc_logs_translator(harvested_data):
         harvested_data.value,
         harvested_data.cycletime,
         None,
+        None,
+        None, 
+        None,
+        None,
         None)
     return result
 
@@ -91,6 +99,10 @@ def daily_bfg_translator(harvested_data):
         'N/A',
         harvested_data.value,
         harvested_data.mediantime,
+        None,
+        None,
+        None, 
+        None,
         None,
         None
     )        

--- a/src/score_db/metric_types.py
+++ b/src/score_db/metric_types.py
@@ -15,8 +15,11 @@ import pprint
 from score_db.db_action_response import DbActionResponse
 import score_db.score_table_models as stm
 from score_db.score_table_models import MetricType as mt
+from score_db.score_table_models import InstrumentMeta as im
+from score_db.instrument_meta import InstrumentMetaRequest
 from score_db import time_utils
 from score_db import db_utils
+import traceback
 
 from pandas import DataFrame
 import sqlalchemy as db
@@ -26,11 +29,12 @@ from sqlalchemy import and_, or_, not_
 from sqlalchemy import asc, desc
 from sqlalchemy.sql import func
 
-MetricTypeData = namedtuple(
-    'MetricTypeData',
+MetricTypeInputData = namedtuple(
+    'MetricTypeInputData',
     [
         'name',
         'long_name',
+        'obs_platform',
         'measurement_type',
         'measurement_units',
         'stat_type',
@@ -38,23 +42,49 @@ MetricTypeData = namedtuple(
     ],
 )
 
+MetricTypeData = namedtuple(
+    'MetricTypeData',
+    [
+        'id',
+        'name',
+        'long_name',
+        'obs_platform',
+        'measurement_type',
+        'measurement_units',
+        'stat_type',
+        'description',
+        'instrument_meta_id',
+        'instrument_name',
+        'instrument_num_channels',
+        'instrument_scan_angle'
+    ],
+)
+
+class MetricTypeError(Exception):
+    def __init__(self, m):
+        self.message = m
+    def __str__(self):
+        return self.message
+
 @dataclass
 class MetricType:
     ''' metric type object storing data related to the measurement type '''
     name: str
     long_name: str
+    obs_platform: str
     measurement_type: str
     measurement_units: str
     stat_type: str
     description: dict
-    metric_type_data: MetricTypeData = field(init=False)
+    metric_type_data: MetricTypeInputData = field(init=False)
 
     def __post_init__(self):
         print(f'in post init name: {self.name}')
         print(f'description: {self.description}')
-        self.metric_type_data = MetricTypeData(
+        self.metric_type_data = MetricTypeInputData(
             self.name,
             self.long_name,
+            self.obs_platform,
             self.measurement_type,
             self.measurement_units,
             self.stat_type,
@@ -85,6 +115,7 @@ def get_metric_type_from_body(body):
     metric_type = MetricType(
         body.get('name'),
         body.get('long_name'),
+        body.get('obs_platform'),
         body.get('measurement_type'),
         body.get('measurement_units'),
         body.get('stat_type'),
@@ -93,14 +124,33 @@ def get_metric_type_from_body(body):
     
     return metric_type
 
-def get_string_filter(filters, cls, key, constructed_filter):
-    if not isinstance(filters, dict):
+def validate_list_of_strings(values):
+    if isinstance(values, str):
+        val_list = []
+        val_list.append(values)
+        return val_list
+
+    if not isinstance(values, list):
+        msg = f'string values must be a list, was: {type(values)}'
+        raise TypeError(msg)
+    
+    for value in values:
+        if not isinstance(value, str):
+            msg = 'all values must be string type - value: ' \
+                f'{value} is type: {type(value)}'
+            raise TypeError(msg)
+    
+    return values
+
+def get_string_filter(filter_dict, cls, key, constructed_filter, key_name):
+    if not isinstance(filter_dict, dict):
         msg = f'Invalid type for filters, must be \'dict\', was ' \
-            f'type: {type(filters)}'
+            f'type: {type(filter_dict)}'
         raise TypeError(msg)
 
     print(f'Column \'{key}\' is of type {type(getattr(cls, key).type)}.')
-    string_flt = filters.get(key)
+    string_flt = filter_dict.get(key_name)
+    print(f'string_flt: {string_flt}')
 
     if string_flt is None:
         print(f'No \'{key}\' filter detected')
@@ -109,12 +159,12 @@ def get_string_filter(filters, cls, key, constructed_filter):
     like_filter = string_flt.get('like')
     # prefer like search over exact match if both exist
     if like_filter is not None:
-        constructed_filter[key] = (getattr(cls, key).like(like_filter))
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).like(like_filter))
         return constructed_filter
 
-    exact_match_filter = string_flt.get('exact')
+    exact_match_filter = validate_list_of_strings(string_flt.get('exact'))
     if exact_match_filter is not None:
-        constructed_filter[key] = (getattr(cls, key) == exact_match_filter)
+        constructed_filter[f'{cls.__name__}.{key}'] = (getattr(cls, key).in_(exact_match_filter))
 
     return constructed_filter
 
@@ -139,22 +189,29 @@ def construct_filters(filters):
     constructed_filter = {}
 
     constructed_filter = get_string_filter(
-        filters, mt, 'name', constructed_filter)
+        filters, mt, 'name', constructed_filter, 'name')
     
     constructed_filter = get_string_filter(
-        filters, mt, 'long_name', constructed_filter)
+        filters, mt, 'long_name', constructed_filter, 'long_name')
+    
+    constructed_filter = get_string_filter(
+        filters, mt, 'obs_platform', constructed_filter, 'obs_platform')
 
     constructed_filter = get_string_filter(
-        filters, mt, 'measurement_type', constructed_filter)
+        filters, mt, 'measurement_type', constructed_filter, 'measurement_type')
 
     constructed_filter = get_string_filter(
-        filters, mt, 'measurement_units', constructed_filter)
+        filters, mt, 'measurement_units', constructed_filter, 'measurement_units')
 
     constructed_filter = get_string_filter(
-        filters, mt, 'stat_type', constructed_filter)
+        filters, mt, 'stat_type', constructed_filter, 'stat_type')
     
     constructed_filter = get_int_filter(
         filters, mt, 'id', constructed_filter)
+    
+    constructed_filter = get_string_filter(filters, im, 'name', constructed_filter, 'instrument_meta_name')
+
+    constructed_filter = get_string_filter(filters, im, 'name', constructed_filter, 'instrument_name') #this way the user could include the meta or not for the filter
     
     return constructed_filter
 
@@ -168,6 +225,65 @@ def get_all_metric_types():
     mtr = MetricTypeRequest(request_dict)
     return mtr.submit()
 
+def get_instrument_meta_id(body):
+    instrument_meta_id = -1
+    try:    
+        instrument_meta_name = body.get('instrument_meta_name')
+    except KeyError as err:
+        print(f'Required instrument meta input value not found: {err}')
+        return instrument_meta_id
+
+    if instrument_meta_name is None:
+        return instrument_meta_id
+
+    instrument_meta_request = {
+        'name': 'instrument_meta',
+        'method': db_utils.HTTP_GET,
+        'params': {
+            'filters': {
+                'name': {
+                    'exact': instrument_meta_name
+                },
+            },
+            'record_limit': 1
+        }
+    }
+
+    print(f'instrument_meta_request: {instrument_meta_request}')
+
+    im_request = InstrumentMetaRequest(instrument_meta_request)
+
+    results = im_request.submit()
+    print(f'results: {results}')
+
+    record_cnt = 0
+    try:
+        if results.success is True:
+            records = results.details.get('records')
+            if records is None:
+                msg = 'Request for instrument meta record did not return a record'
+                raise MetricTypeError(msg)
+            record_cnt = records.shape[0]
+        else:
+            msg = f'Problems encountered requesting instrument meta data.'
+            # create error return db_action_response
+            raise MetricTypeError(msg)
+        if record_cnt <= 0:
+            msg = 'Request for instrument meta record did not return a record'
+            raise MetricTypeError(msg)
+        
+    except Exception as err:
+        msg = f'Problems encountered requesting instrument meta data. err - {err}'
+        raise MetricTypeError(msg)
+        
+    try:
+        instrument_meta_id = records[im.id.name].iat[0]
+    except Exception as err:
+        error_msg = f'Problem finding instrument meta id from record: {records} ' \
+            f'- err: {err}'
+        print(f'error_msg: {error_msg}')
+        raise MetricTypeError(error_msg) 
+    return instrument_meta_id
 
 @dataclass
 class MetricTypeRequest:
@@ -180,6 +296,7 @@ class MetricTypeRequest:
     body: dict = field(default_factory=dict, init=False)
     metric_type: MetricType = field(init=False)
     metric_type_data: namedtuple = field(init=False)
+    instrument_meta_id: int = field(default_factory=int, init=False)
     response: dict = field(default_factory=dict, init=False)
 
 
@@ -189,16 +306,21 @@ class MetricTypeRequest:
 
         self.body = self.request_dict.get('body')
         if self.method == db_utils.HTTP_PUT:
-            self.metric_type = get_metric_type_from_body(self.body)
-            # pprint(f'metric_type : {repr(self.metric_type)}')
-            self.metric_type_data = self.metric_type.get_metric_type_data()
+            try:
+                self.metric_type = get_metric_type_from_body(self.body)
+                self.metric_type_data = self.metric_type.get_metric_type_data()
+                self.instrument_meta_id = get_instrument_meta_id(self.body)
+            except Exception as err:
+                error_msg = 'Failed to get metric type information to insert -' \
+                    f' err: {err}'
+                print(f'Submit PUT error: {error_msg}')
+                return self.failed_request(error_msg)
             for k, v in zip(
                 self.metric_type_data._fields, self.metric_type_data
             ):
                 val = pprint.pformat(v, indent=4)
                 print(f'exp_data: k: {k}, v: {val}')
         else:
-            print(f'In MetricTypeRequest - params: {self.params}')
             if isinstance(self.params, dict):
                 self.filters = construct_filters(self.params.get('filters'))
                 self.ordering = self.params.get('ordering')
@@ -244,9 +366,13 @@ class MetricTypeRequest:
 
     
     def put_metric_type(self, session):
+        instrument_meta_id = self.instrument_meta_id if self.instrument_meta_id > 0 else None
+
         insert_stmt = insert(mt).values(
             name=self.metric_type_data.name,
             long_name = self.metric_type_data.long_name,
+            obs_platform=self.metric_type_data.obs_platform,
+            instrument_meta_id=instrument_meta_id, 
             measurement_type=self.metric_type_data.measurement_type,
             measurement_units=self.metric_type_data.measurement_units,
             stat_type=self.metric_type_data.stat_type,
@@ -261,7 +387,7 @@ class MetricTypeRequest:
         do_update_stmt = insert_stmt.on_conflict_do_update(
             constraint='unique_metric_type',
             set_=dict(
-                # group_id=self.experiment_data.group_id,
+                obs_platform=self.metric_type_data.obs_platform,
                 long_name=self.metric_type_data.long_name, 
                 measurement_units=self.metric_type_data.measurement_units,
                 stat_type=self.metric_type_data.stat_type,
@@ -279,9 +405,6 @@ class MetricTypeRequest:
             action = db_utils.INSERT
             if result_row.updated_at is not None:
                 action = db_utils.UPDATE
-            # print(f'result.fetchone(): {result_row}')
-            # print(f'updated_at: {result_row.updated_at}')
-            # print(f'result.fetchone().keys(): {result_row._mapping}')
 
             session.commit()
         except Exception as err:
@@ -312,17 +435,9 @@ class MetricTypeRequest:
     
     def get_metric_types(self, session):
         q = session.query(
-            mt.id,
-            mt.name,
-            mt.long_name,
-            mt.measurement_type,
-            mt.measurement_units,
-            mt.stat_type,
-            mt.description,
-            mt.created_at,
-            mt.updated_at
-        ).select_from(
             mt
+        ).outerjoin(
+            im, mt.instrument_meta
         )
 
         print('Before adding filters to metric types request########################')
@@ -344,12 +459,57 @@ class MetricTypeRequest:
 
         metric_types = q.all()
 
+        parsed_types = []
+        for metric_type in metric_types:
+            if metric_type.instrument_meta is not None:
+                record = MetricTypeData(
+                id=metric_type.id,
+                name=metric_type.name,
+                long_name=metric_type.long_name,
+                obs_platform=metric_type.obs_platform,
+                measurement_type=metric_type.measurement_type,
+                measurement_units=metric_type.measurement_units,
+                stat_type=metric_type.stat_type,
+                description=metric_type.description,
+                instrument_meta_id=metric_type.instrument_meta.id,
+                instrument_name=metric_type.instrument_meta.name,
+                instrument_num_channels=metric_type.instrument_meta.num_channels,
+                instrument_scan_angle=metric_type.instrument_meta.scan_angle
+            )
+            else:
+                record = MetricTypeData(
+                    id=metric_type.id,
+                    name=metric_type.name,
+                    long_name=metric_type.long_name,
+                    obs_platform=metric_type.obs_platform,
+                    measurement_type=metric_type.measurement_type,
+                    measurement_units=metric_type.measurement_units,
+                    stat_type=metric_type.stat_type,
+                    description=metric_type.description,
+                    instrument_meta_id=None,
+                    instrument_name=None,
+                    instrument_num_channels=None,
+                    instrument_scan_angle=None
+                )
+            parsed_types.append(record)
+
+        try:
+            metric_types_df = DataFrame(
+                parsed_types,
+                columns=MetricTypeData._fields
+            )
+        except Exception as err:
+            trcbk = traceback.format_exc()
+            msg = f'Problem casting array metric type query output into pandas ' \
+                f'DataFrame - err: {trcbk}'
+            raise TypeError(msg) from err
+
         results = DataFrame()
         error_msg = None
         record_count = 0
         try:
-            if len(metric_types) > 0:
-                results = DataFrame(metric_types, columns = metric_types[0]._fields)
+            if len(parsed_types) > 0:
+                results = metric_types_df
             
         except Exception as err:
             message = 'Request for metric type records FAILED'

--- a/src/score_db/score_table_models.py
+++ b/src/score_db/score_table_models.py
@@ -115,6 +115,7 @@ class ExperimentMetric(Base):
     experiment_id = Column(Integer, ForeignKey('experiments.id'))
     metric_type_id = Column(Integer, ForeignKey('metric_types.id'))
     region_id = Column(Integer, ForeignKey('regions.id'))
+    sat_meta_id = Column(Integer, ForeignKey('sat_meta.id'), nullable=True)
     elevation = Column(Float)
     elevation_unit = Column(String(32))
     value = Column(Float)
@@ -126,7 +127,7 @@ class ExperimentMetric(Base):
     experiment = relationship('Experiment', back_populates='metrics')
     metric_type = relationship('MetricType', back_populates='metrics')
     region = relationship('Region', back_populates='metrics')
-
+    sat_meta = relationship('SatMeta', back_populates='metrics')
 
 class Region(Base):
     __tablename__ = REGIONS_TABLE
@@ -156,11 +157,15 @@ class MetricType(Base):
             'measurement_type',
             'measurement_units',
             'stat_type',
+            'obs_platform',
+            'instrument_meta_id',
             name='unique_metric_type'
         ),
     )
     
     id = Column(Integer, primary_key=True, autoincrement=True)
+    obs_platform = Column(String(128), nullable=True)
+    instrument_meta_id = Column(Integer, ForeignKey('instrument_meta.id'), nullable=True)
     name = Column(String(128), nullable=False)
     long_name = Column(String(128))
     measurement_type = Column(String(64), nullable=False)
@@ -171,6 +176,7 @@ class MetricType(Base):
     updated_at = Column(DateTime)
     
     metrics = relationship('ExperimentMetric', back_populates='metric_type')
+    instrument_meta = relationship('InstrumentMeta', back_populates='metric_type')
 
 class StorageLocation(Base):
     __tablename__ = STORAGE_LOCATION_TABLE
@@ -307,6 +313,7 @@ class SatMeta(Base):
     updated_at = Column(DateTime) 
 
     array_metrics = relationship('ExptArrayMetric', back_populates='sat_meta')
+    metrics = relationship('ExperimentMetric', back_populates='sat_meta')
 
 class InstrumentMeta(Base):
     __tablename__ = INSTRUMENT_META_TABLE
@@ -325,6 +332,7 @@ class InstrumentMeta(Base):
     updated_at = Column(DateTime) 
 
     array_metric_type = relationship('ArrayMetricType', back_populates='instrument_meta')
+    metric_type = relationship('MetricType', back_populates='instrument_meta')
 
 
 

--- a/tests/test_expt_metrics_handler.py
+++ b/tests/test_expt_metrics_handler.py
@@ -17,8 +17,8 @@ def test_put_exp_metrics_request_dict():
             'expt_name': 'C96L64.UFSRNR.GSI_3DVAR.012016',
             'expt_wallclock_start': '2021-07-22 09:22:05',
             'metrics': [
-                ExptMetricInputData('innov_stats_temperature_rmsd', 'global', '0', 'kpa', 2.6, '2015-12-02 06:00:00', None, None),
-                ExptMetricInputData('innov_stats_uvwind_rmsd', 'tropics', '50', 'kpa', 2.8, '2015-12-02 06:00:00', 24, 256)
+                ExptMetricInputData('innov_stats_temperature_rmsd', 'global', '0', 'kpa', 2.6, '2015-12-02 06:00:00', None, None, None, None, None, None),
+                ExptMetricInputData('innov_stats_uvwind_rmsd', 'tropics', '50', 'kpa', 2.8, '2015-12-02 06:00:00', 24, 256,  None, None, None, None)
             ],
             'datestr_format': '%Y-%m-%d %H:%M:%S'
         }

--- a/tests/test_expt_metrics_handler.py
+++ b/tests/test_expt_metrics_handler.py
@@ -76,3 +76,77 @@ def test_send_get_request():
     result = emr.submit()
     assert(result.success)
     assert(result.details.get('record_count') > 0)
+
+def test_put_exp_metrics_request_dict_with_sats():
+
+    request_dict = {
+        'db_request_name': 'expt_metrics',
+        'method': 'PUT',
+        'body': {
+            'expt_name': 'C96L64.UFSRNR.GSI_3DVAR.012016',
+            'expt_wallclock_start': '2021-07-22 09:22:05',
+            'metrics': [
+                ExptMetricInputData('innov_stats_temperature_rmsd', 'global', '0', 'kpa', 2.6, '2015-12-02 06:00:00', None, None, 'example_sat_meta', 123456789, 'Example Sat Name', 'esm_1'),
+                ExptMetricInputData('innov_stats_uvwind_rmsd', 'tropics', '50', 'kpa', 2.8, '2015-12-02 06:00:00', 24, 256,  None, 123456789, None, None)
+            ],
+            'datestr_format': '%Y-%m-%d %H:%M:%S'
+        }
+    }
+
+    emr = ExptMetricRequest(request_dict)
+    result = emr.submit()
+    print(f'Experiment metrics PUT result: {result}')
+    assert(result.success)
+
+def test_send_get_request_with_sats():
+
+    request_dict = {
+        'db_request_name': 'expt_metrics',
+        'method': 'GET',
+        'params': {
+            'datestr_format': '%Y-%m-%d %H:%M:%S',
+            'filters': {
+                'experiment': {
+                    'name': {
+                        'exact': 'C96L64.UFSRNR.GSI_3DVAR.012016',
+                    },
+                    'wallclock_start': {
+                        'from': '2021-07-22 02:22:05',
+                        'to': '2021-07-22 10:22:05'
+                    }
+                },
+                'metric_types': {
+                    'name': {
+                        'exact': ['innov_stats_temperature_rmsd']
+                    },
+                    'stat_type': {
+                        'exact': ['rmsd']
+                    }
+                },
+                'regions': {
+                    'name': {
+                        'exact': ['global']
+                    },
+                },
+                'sat_meta': {
+                    'name': {
+                        'exact' : 'example_sat_meta'
+                    }
+                },
+
+                'time_valid': {
+                    'from': '2015-01-01 00:00:00',
+                    'to': '2016-01-03 00:00:00',
+                },
+            },
+            'ordering': [
+                # {'name': 'id', 'order_by': 'asc'}
+                {'name': 'time_valid', 'order_by': 'asc'}
+            ]
+        }
+    }
+
+    emr = ExptMetricRequest(request_dict)
+    result = emr.submit()
+    assert(result.success)
+    assert(result.details.get('record_count') > 0)

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -12,7 +12,7 @@ import json
 from collections import namedtuple
 
 import score_db.metric_types as mts
-from score_db.metric_types import MetricTypeData, MetricType, MetricTypeRequest
+from score_db.metric_types import MetricTypeInputData, MetricType, MetricTypeRequest
 
 from score_db.score_db_base import handle_request
 

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -224,7 +224,59 @@ def test_send_get_request():
         }
     }
 
-    er = MetricTypeRequest(request_dict)
-    result = er.submit()
+    mtr = MetricTypeRequest(request_dict)
+    result = mtr.submit()
+    assert(result.success)
+    assert(result.details.get('record_count') > 0)
+
+
+
+def test_put_metric_type_with_instrument():
+    request_dict = {
+        'db_request_name': 'metric_types',
+        'method': 'PUT',
+        'body': {
+            'name': 'example_metric_inst',
+            'longname': 'long name with instrument',
+            'obs_platform': 'satellite',
+            'measurement_type': 'example_measurement_type',
+            'measurement_units': 'example_measurement_units',
+            'stat_type': 'example_stat',
+            'description': json.dumps("example metric type for testing purposes"),
+            'instrument_meta_name': 'example_instrument',
+        }
+    }
+
+    mtr = MetricTypeRequest(request_dict)
+    result = mtr.submit()
+    assert(result.success)
+
+def test_send_get_request_with_instrument():
+
+    request_dict = {
+        'db_request_name': 'metric_types',
+        'method': 'GET',
+        'params': {
+            'filters': {
+                'name': {
+                    'exact': 'example_metric_inst',
+                },
+                'instrument_meta_name':{
+                    'exact': 'example_instrument'
+                },
+                'stat_type':{
+                    'exact':'example_stat'
+                }
+            },
+            'ordering': [
+                {'name': 'name', 'order_by': 'desc'},
+                {'name': 'created_at', 'order_by': 'desc'}
+            ],
+            'record_limit': 4
+        }
+    }
+
+    mtr = MetricTypeRequest(request_dict)
+    result = mtr.submit()
     assert(result.success)
     assert(result.details.get('record_count') > 0)

--- a/tests/test_metric_types_handler.py
+++ b/tests/test_metric_types_handler.py
@@ -280,3 +280,22 @@ def test_send_get_request_with_instrument():
     result = mtr.submit()
     assert(result.success)
     assert(result.details.get('record_count') > 0)
+
+def test_put_metric_type_for_harvest_test():
+    request_dict = {
+        'db_request_name': 'metric_types',
+        'method': 'PUT',
+        'body': {
+            'name': 'mean_o3mr_inc',
+            'longname': 'Mean Ozone Mixing Ratio',
+            'obs_platform': None,
+            'measurement_type': 'o3mr_inc',
+            'measurement_units': 'kg/kg',
+            'stat_type': 'mean',
+            'description': json.dumps("longname is Mean Ozone Mixing Ratio"),
+        }
+    }
+
+    mtr = MetricTypeRequest(request_dict)
+    result = mtr.submit()
+    assert(result.success)


### PR DESCRIPTION
This PR connects the instrument meta and sat meta tables to the expt_metrics and metric_types tables in a similar manner to the existing array based metric tables. This allowed the user to optionally include an instrument meta, obs platform, and sat meta to the 'single' metrics or the array metrics. The new columns all match the existing array based table columns. All newly added fields are nullable and will not break any existing functionality. 

New tests are added to verify the functionality and existing tests are passing on the test database. The usage of the new columns were also independently verified as successful in the test database. 

These table changes require manual updates to add the necessary columns and foreign keys to the schema of the existing SQL database in order to function properly due to the nature of sqlalchemy not tracking schema changes. 