### PR TITLE
include sat meta in defining uniqueness for duplicate drop

### DIFF
--- a/src/score_db/expt_array_metrics.py
+++ b/src/score_db/expt_array_metrics.py
@@ -839,6 +839,7 @@ class ExptArrayMetricRequest:
                     'expt_id',
                     'metric_id',
                     'region_id',
+                    'sat_meta_id'
                 ],
                 keep='last'
             )

--- a/src/score_db/expt_metrics.py
+++ b/src/score_db/expt_metrics.py
@@ -887,7 +887,8 @@ class ExptMetricRequest:
                     'ensemble_member',
                     'expt_id',
                     'metric_id',
-                    'region_id'
+                    'region_id',
+                    'sat_meta_id'
                 ],
                 keep='last'
             )


### PR DESCRIPTION
This is a hot-fix to address a bug where data for the same metric type, experiment, region, and time_valid could be dropped as a duplicate for different satellites. Now, when dropping duplicate values, sat_meta_id is included as a field for uniqueness for both expt array metrics and expt metrics. 

Tests for the files are both passing. In the future, it is advised to write more specific test cases which verify the duplicate drop and filter behaviors are correct and check the number of returned values is accurate. 