### PR TITLE
Support for translating background versus analysis metric data from score-hv

### DIFF
--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -98,6 +98,7 @@ def daily_bfg_translator(harvested_data):
         'HarvestedData', 
         [
             'filenames',
+            'segment',
             'statistic',
             'variable',
             'value',
@@ -107,8 +108,16 @@ def daily_bfg_translator(harvested_data):
         ]
     )
     """
+
+    metric_name = harvested_data.statistic + "_" + harvested_data.variable,
+    
+    if harvested_data.segment == 'background':
+        metric_name += '_fg'
+    elif harvested_data.segment == 'analysis':
+        metric_name += '_an'
+    
     result = MetricTableData(
-        harvested_data.statistic + "_" + harvested_data.variable,
+        metric_name,
         'global',
         None,
         None,

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -112,7 +112,7 @@ def daily_bfg_translator(harvested_data):
     metric_name = harvested_data.statistic + "_" + harvested_data.variable,
     
     if harvested_data.segment == 'background':
-        metric_name += '_fg'
+        metric_name += '_bg'
     elif harvested_data.segment == 'analysis':
         metric_name += '_an'
     


### PR DESCRIPTION
Modifies the daily_bfg harvest translator, so that it accounts for background (_fg) versus analysis (_an) in metric name.