### PR TITLE
Fix missing plus sign to the soca diags harvest translator

### DIFF
--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -205,7 +205,7 @@ def soca_diags_translator(harvested_data):
         instrument_type = harvested_data.sensor
     
     result = MetricTableData(
-        harvested_data.statistics + "_" + harvested_data.variables "_" +
+        harvested_data.statistics + "_" + harvested_data.variables + "_" +
         instrument_type + "_" + harvested_data.group, # name
         harvested_data.file_region, # region_name
         None, # region_min_lat

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -216,6 +216,7 @@ def soca_diags_translator(harvested_data):
         'N/A', # elevation_unit
         harvested_data.value, # value
         harvested_data.filetime, # cycletime
+        None, # forecast_hour
         None, # ensemble_member
         harvested_data.level, # level
         None, # sat_meta_name


### PR DESCRIPTION
The harvest translator broke due to a missing plus sign for string concatenation of the metric name associated with SOCA diags. This PR fixes the syntax and now runs successfully.