### PR TITLE
add usage to SOCA diags harvest_translator

### DIFF
--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -224,6 +224,7 @@ def soca_diags_translator(harvested_data):
         None, # forecast_hour
         None, # ensemble_member
         harvested_data.level, # level
+        None, # usage
         None, # sat_meta_name
         None, # sat_id
         None, # sat_name


### PR DESCRIPTION
I believe this PR, which adds an entry for "usage" to the SOCA diags harvest_translator, is needed to maintain support for SOCA diags following [this recent PR merged into develop](https://github.com/NOAA-PSL/score-db/pull/66).