### PR TITLE
support for GSI stats for conventional data

### DIFF
--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -207,13 +207,13 @@ def gsi_conventional_obs_translator(harvested_data, surface_level_only=False):
         ]
     )
     """
-    # There are a few metrics for which are surface level only. Conditions
-    # for surface only data are defined first
+    # There are a few metrics for which are single level only. Conditions
+    # for single level data are defined first
     
     if harvested_data.variable == 'fit_psfc_data':
-        surface_level_only = True
-    if harvested_data.plevs_top == [0.100E+04] and harvested_data.plevs_bot == [0.120E+04]:
-        surface_level_only = True
+        single_level_only = True
+    if harvested_data.plevs_top == [0.000E+00] and harvested_data.plevs_bot == [0.200E+04]:
+        single_level_only = True
     
     if harvested_data.usage == 'asm':
         assimilated = True
@@ -238,7 +238,7 @@ def gsi_conventional_obs_translator(harvested_data, surface_level_only=False):
 
     metric_name = f"{harvested_data.statistic}_{harvested_data.variable}_{str(harvested_data.type)}_GSIstage_{str(harvested_data.iteration)}"
     
-    if surface_level_only:
+    if single_level_only:
         assert len(harvested_data.values) == 1
         value = harvested_data.values[0]
         

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -186,7 +186,7 @@ def gsi_satellite_radiance_channel_translator(harvested_data):
     
     return result
 
-def gsi_conventional_obs_translator(harvested_data, surface_level_only=False):
+def gsi_conventional_obs_translator(harvested_data):
     """Expected output from gsi_conventional_obs_channel harvester
     gsi_conventional_obs_harvested_data = namedtuple(
         'HarvestedData', [
@@ -230,11 +230,6 @@ def gsi_conventional_obs_translator(harvested_data, surface_level_only=False):
                           f'{harvested_data.ensemble_member} to int, storing '
                           f'as NoneType')
             ensemble_member = None
-    
-    if harvested_data.subtype is None or harvested_data.subtype =='None':
-        subtype = 'None'
-    else:
-        subtype = f'{harvested_data.subtype}'
 
     metric_name = f"{harvested_data.statistic}_{harvested_data.variable}_{str(harvested_data.type)}_GSIstage_{str(harvested_data.iteration)}"
     

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -212,8 +212,10 @@ def gsi_conventional_obs_translator(harvested_data):
     
     if harvested_data.variable == 'fit_psfc_data':
         single_level_only = True
-    if harvested_data.plevs_top == [0.000E+00] and harvested_data.plevs_bot == [0.200E+04]:
+    elif harvested_data.plevs_top == [0.000E+00] and harvested_data.plevs_bot == [0.200E+04]:
         single_level_only = True
+    else:
+        single_level_only = False
     
     if harvested_data.usage == 'asm':
         assimilated = True

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -225,30 +225,55 @@ def gsi_conventional_obs_translator(harvested_data):
             ensemble_member = None
     
     if harvested_data.subtype is None or harvested_data.subtype =='None':
-        #TODO: Determine how best to store obs type and subtype
         subtype = 'None'
     else:
         subtype = f'{harvested_data.subtype}'
 
-    result = ArrayMetricTableData(
-        harvested_data.statistic + '_' + harvested_data.variable + '_' + 
-        harvested_data.type + '_' + subtype + "_GSIstage_" + str(harvested_data.iteration),
-        'global',
-        None,
-        None,
-        None,
-        None,
-        harvested_data.values,
-        assimilated,
-        harvested_data.datetime,
-        None,
-        ensemble_member,
-        None,
-        harvested_data.usage,
-        None,
-        None,
-        None,
-        None,
+    metric_name = f"{harvested_data.statistic}_{harvested_data.variable}_{str(harvested_data.type)}_GSIstage_{str(harvested_data.iteration)}"
+    
+    
+    if harvested_data.variable == 'fit_psfc_data':
+        # scalar metric type
+        result = MetricTableData(
+            metric_name,
+            'global',
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            harvested_data.values,
+            Harvested_data.datetime,
+            None,
+            ensemble_member,
+            None,
+            harvested_data.usage,
+            None,
+            None,
+            None,
+            None,
+        )
+    else:
+        # array metric type
+        result = ArrayMetricTableData(
+            metric_name,
+            'global',
+            None,
+            None,
+            None,
+            None,
+            harvested_data.values,
+            assimilated,
+            harvested_data.datetime,
+            None,
+            ensemble_member,
+            None,
+            harvested_data.usage,
+            None,
+            None,
+            None,
+            None,
     )
     
     return result

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -186,7 +186,7 @@ def gsi_satellite_radiance_channel_translator(harvested_data):
     
     return result
 
-def gsi_conventional_obs_translator(harvested_data):
+def gsi_conventional_obs_translator(harvested_data, surface_level_only=False):
     """Expected output from gsi_conventional_obs_channel harvester
     gsi_conventional_obs_harvested_data = namedtuple(
         'HarvestedData', [
@@ -207,6 +207,13 @@ def gsi_conventional_obs_translator(harvested_data):
         ]
     )
     """
+    # There are a few metrics for which are surface level only. Conditions
+    # for surface only data are defined first
+    
+    if harvested_data.variable == 'fit_psfc_data':
+        surface_level_only = True
+    if harvested_data.plevs_top == [0.100E+04] and harvested_data.plevs_bot == [0.120E+04]:
+        surface_level_only = True
     
     if harvested_data.usage == 'asm':
         assimilated = True
@@ -231,8 +238,10 @@ def gsi_conventional_obs_translator(harvested_data):
 
     metric_name = f"{harvested_data.statistic}_{harvested_data.variable}_{str(harvested_data.type)}_GSIstage_{str(harvested_data.iteration)}"
     
-    
-    if harvested_data.variable == 'fit_psfc_data':
+    if surface_level_only:
+        assert len(harvested_data.values) == 1
+        value = harvested_data.values[0]
+        
         # scalar metric type
         result = MetricTableData(
             metric_name,
@@ -243,8 +252,8 @@ def gsi_conventional_obs_translator(harvested_data):
             None,
             None,
             None,
-            harvested_data.values,
-            Harvested_data.datetime,
+            value,
+            harvested_data.datetime,
             None,
             ensemble_member,
             None,

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -185,7 +185,74 @@ def gsi_satellite_radiance_channel_translator(harvested_data):
     )
     
     return result
+
+def gsi_conventional_obs_translator(harvested_data):
+    """Expected output from gsi_conventional_obs_channel harvester
+    gsi_conventional_obs_harvested_data = namedtuple(
+        'HarvestedData', [
+            'datetime', # datetime.datetime object (date and a time)
+            'ensemble_member',
+            'plevs_top', # pressures at the layer tops (for multi-level data)
+            'plevs_bot', # pressures at the layer bottoms (for multi-level data)
+            'plevs_units',
+            'variable',
+            'statistic',
+            'values',
+            'units',
+            'longname',
+            'iteration', # GSI outer loop number
+            'usage', # used (asm), read in but not assimilated (mon) or rejected (rej)
+            'type', # prepbufr obs type
+            'subtype', # prepbufr obs subtype
+        ]
+    )
+    """
     
+    if harvested_data.usage == 'asm':
+        assimilated = True
+    else:
+        assimilated = False
+    
+    if harvested_data.ensemble_member == 'control':
+        ensemble_member = None
+    else:
+        try:
+            ensemble_member = int(harvested_data.ensemble_member)
+        except ValueError:
+            warnings.warn('could not convert harvested_data.ensemble_member '
+                          f'{harvested_data.ensemble_member} to int, storing '
+                          f'as NoneType')
+            ensemble_member = None
+    
+    if harvested_data.subtype is None or harvested_data.subtype =='None':
+        #TODO: Determine how best to store obs type and subtype
+        subtype = 'None'
+    else:
+        subtype = f'{harvested_data.subtype}'
+
+    result = ArrayMetricTableData(
+        harvested_data.statistic + '_' + harvested_data.variable + '_' + 
+        harvested_data.type + '_' + subtype + "_GSIstage_" + str(harvested_data.iteration),
+        'global',
+        None,
+        None,
+        None,
+        None,
+        harvested_data.values,
+        assimilated,
+        harvested_data.datetime,
+        None,
+        ensemble_member,
+        None,
+        harvested_data.usage,
+        None,
+        None,
+        None,
+        None,
+    )
+    
+    return result
+
 def soca_diags_translator(harvested_data):
     """Expected output from soca_diags harvester
     HarvestedData = namedtuple('HarvestedData',

--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -235,8 +235,7 @@ def gsi_conventional_obs_translator(harvested_data):
 
     metric_name = f"{harvested_data.statistic}_{harvested_data.variable}_{str(harvested_data.type)}_GSIstage_{str(harvested_data.iteration)}"
     
-    if single_level_only:
-        assert len(harvested_data.values) == 1
+    if single_level_only and len(harvested_data.values) == 1:
         value = harvested_data.values[0]
         
         # scalar metric type
@@ -260,7 +259,7 @@ def gsi_conventional_obs_translator(harvested_data):
             None,
             None,
         )
-    else:
+    elif not single_level_only:
         # array metric type
         result = ArrayMetricTableData(
             metric_name,
@@ -281,6 +280,8 @@ def gsi_conventional_obs_translator(harvested_data):
             None,
             None,
     )
+    else:
+        raise ValueError(f"trying to store scalar metric type but harvested array: {harvested_data.values}")
     
     return result
 

--- a/src/score_db/hv_translator_registry.py
+++ b/src/score_db/hv_translator_registry.py
@@ -32,6 +32,10 @@ translator_registry = {
         'translate harvest values from gsi_satellite_radiance_channel harvester',
         harvest_translator.gsi_satellite_radiance_channel_translator
     ),
+    'gsi_conventional_obs': TranslatorHandler(
+        'translate harvest values from gsi_conventional_obs harvester',
+        harvest_translator.gsi_conventional_obs_translator
+    ),
     'soca_diags': TranslatorHandler(
         'translate harvest values from soca_diags harvester',
         harvest_translator.soca_diags_translator


### PR DESCRIPTION
Support to harvest and add to the database GSI statistics from conventional observations. PR includes:

- new entry to the hv_translator_registry
- gsi_conventional_obs_translator function in harvest_translator.py

Existing unit tests pass.