### PR TITLE
translate from score-hv SOCA diags effective QC -> usage

### DIFF
--- a/src/score_db/harvest_translator.py
+++ b/src/score_db/harvest_translator.py
@@ -209,7 +209,8 @@ def soca_diags_translator(harvested_data):
          'statistics',
          'value',
          'filetime',
-         'file_region']
+         'file_region',
+         'QC_threshold']
     )
     """
     
@@ -217,6 +218,13 @@ def soca_diags_translator(harvested_data):
         instrument_type = 'insitu'
     else:
         instrument_type = harvested_data.sensor
+        
+    if harvested_data.QC_threshold is None:
+        usage='noQC'
+    elif harvested_data.QC_threshold > 0:
+        usage=f'effectiveQC_lt_{harvested_data.QC_threshold}'
+    elif harvested_data.QC_threshold == 0:
+        usage='effectiveQC_eq_0' 
     
     result = MetricTableData(
         harvested_data.statistics + "_" + harvested_data.variables + "_" +
@@ -233,7 +241,7 @@ def soca_diags_translator(harvested_data):
         None, # forecast_hour
         None, # ensemble_member
         harvested_data.level, # level
-        None, # usage
+        usage, # usage
         None, # sat_meta_name
         None, # sat_id
         None, # sat_name


### PR DESCRIPTION
This PR adds to the harvest translator support for storing information related to the SOCA diags effective QC.

effectiveQC is used in the SOCA diag files to indicate usage by the DA system, where effectiveQC = 0 indicates data were assimilated. score-db already supports storing usage information, and this PR adds harvested usage info from score-hv using the preexisting usage attribute for metrics via harvest_translator.py 

